### PR TITLE
fix: Android 4-button alert limit in recurrence scope dialog

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,5 +21,5 @@ keywords:
   - nextcloud
   - calendar
 license: Apache-2.0
-version: 1.2.2
+version: 1.3.0
 date-released: '2026-05-09'

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Nextcloud Calendar",
     "slug": "nextcloud-calendar",
     "scheme": "nextcloud-calendar",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "orientation": "portrait",
     "userInterfaceStyle": "automatic",
     "platforms": [

--- a/app/event/[uid].tsx
+++ b/app/event/[uid].tsx
@@ -50,7 +50,11 @@ function askRecurrenceScope(
       onPress: () => onSelect('all'),
     },
     { text: strings.cancel, style: 'cancel' },
-  ]);
+  ],
+    {
+      cancelable: true,
+    },
+ );
 }
 
 export default function EventDetailScreen() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nextcloud-calendar",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",


### PR DESCRIPTION
The recurrence scope picker (shown when editing/deleting a recurring event) used React Native's Alert.alert with 4 buttons. 
On Android, the native platform limits the dialog to 3 buttons, so the cancel button was silently dropped, leaving the user unable to dismiss the dialog without selecting an option.

<img width="720" height="1600" alt="image" src="https://github.com/user-attachments/assets/0d0a665a-9e54-4e4b-a43a-62c247dc159f" />
