### PR TITLE
fix(caldav): discover DAV user id instead of assuming login name

### DIFF
--- a/src/services/nextcloud/caldav.ts
+++ b/src/services/nextcloud/caldav.ts
@@ -68,18 +68,82 @@ async function davFetch(
   }
 }
 
+const CURRENT_USER_PRINCIPAL_BODY =
+  '<?xml version="1.0" encoding="utf-8"?>' +
+  '<d:propfind xmlns:d="DAV:"><d:prop><d:current-user-principal/></d:prop></d:propfind>';
+
+const CALENDAR_HOME_SET_BODY =
+  '<?xml version="1.0" encoding="utf-8"?>' +
+  '<d:propfind xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">' +
+  '<d:prop><cal:calendar-home-set/></d:prop></d:propfind>';
+
+/**
+ * Extracts the first <d:href> nested inside the given property element.
+ * Namespace prefixes are server-defined, so match on the local name only.
+ */
+function extractPropHref(xml: string, localName: string): string | undefined {
+  const prop = new RegExp(
+    `<[^>]*\\b${localName}\\b[^>]*>([\\s\\S]*?)<\\/[^>]*\\b${localName}\\b[^>]*>`,
+    'i',
+  ).exec(xml);
+  if (!prop) return undefined;
+  const href = /<[^>]*\bhref\b[^>]*>([\s\S]*?)<\/[^>]*\bhref\b[^>]*>/i.exec(prop[1]);
+  if (!href) return undefined;
+  const value = decodeXmlEntities(href[1]).trim();
+  return value.length > 0 ? value : undefined;
+}
+
+/**
+ * Resolves the DAV user id used in calendar paths.
+ *
+ * The DAV user id is NOT always the login name. With an external user backend
+ * (LDAP / Active Directory) Nextcloud derives the internal username from the
+ * directory UUID, so a user logging in as `jdoe` may own calendars under
+ * `/remote.php/dav/calendars/8F3A...-B602-.../`. Assuming the two are equal
+ * makes discovery silently return zero calendars for those accounts.
+ *
+ * We therefore ask the server instead of guessing (RFC 5397 + RFC 4791):
+ *   1. PROPFIND /remote.php/dav/ for <d:current-user-principal>
+ *   2. PROPFIND that principal for <cal:calendar-home-set>
+ *
+ * Falls back to the login name so setups that never advertised these
+ * properties keep working exactly as before.
+ */
 export async function validateCredentials(params: {
   baseUrl: string;
   username: string;
   appPassword: string;
 }): Promise<{ davUserId: string }> {
-  const url = `${params.baseUrl}/remote.php/dav/principals/users/${encodeURIComponent(params.username)}/`;
-  const res = await davFetch(url, params, {
+  const davRoot = `${params.baseUrl}/remote.php/dav/`;
+
+  const rootRes = await davFetch(davRoot, params, {
     method: 'PROPFIND',
     headers: { Depth: '0', 'Content-Type': 'application/xml' },
+    body: CURRENT_USER_PRINCIPAL_BODY,
   });
-  if (res.status !== 207 && !res.ok) throw httpErrorFrom(res, 'validateCredentials');
-  return { davUserId: params.username };
+  if (rootRes.status !== 207 && !rootRes.ok) {
+    throw httpErrorFrom(rootRes, 'validateCredentials');
+  }
+
+  const principalPath = extractPropHref(await rootRes.text(), 'current-user-principal');
+  if (!principalPath) return { davUserId: params.username };
+
+  const origin = new URL(params.baseUrl).origin;
+  const principalUrl = new URL(principalPath, origin).toString();
+
+  const homeRes = await davFetch(principalUrl, params, {
+    method: 'PROPFIND',
+    headers: { Depth: '0', 'Content-Type': 'application/xml' },
+    body: CALENDAR_HOME_SET_BODY,
+  });
+  if (homeRes.status !== 207 && !homeRes.ok) {
+    return { davUserId: extractSlug(principalPath) || params.username };
+  }
+
+  const homePath = extractPropHref(await homeRes.text(), 'calendar-home-set');
+  const davUserId = extractSlug(homePath ?? principalPath);
+
+  return { davUserId: davUserId || params.username };
 }
 
 export interface SyncCollectionResult {


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>fix(caldav): discover the DAV user id instead of assuming it equals the login name</h1>
<p>Closes #52</p>
<h2>Problem</h2>
<p><code>validateCredentials()</code> returns <code>{ davUserId: params.username }</code>, and <code>calUrl()</code>
builds every calendar path from that value:</p>
<pre><code class="language-ts">`${account.baseUrl}/remote.php/dav/calendars/${encodeURIComponent(account.davUserId)}/${path}`
</code></pre>
<p>This assumes the login name and the DAV user id are the same. That holds for the
default database backend, but <strong>not</strong> for external user backends.</p>
<p>With LDAP / Active Directory, Nextcloud derives the internal username from the
directory UUID unless an explicit <em>Internal Username</em> attribute is configured —
and auto-detecting the UUID attribute is the documented default behaviour
(see the <a href="https://docs.nextcloud.com/server/stable/admin_manual/configuration_user/user_auth_ldap.html">LDAP admin manual</a>).</p>
<p>So a user logging in as <code>jdoe</code> owns calendars under:</p>
<pre><code>/remote.php/dav/calendars/143A944C-B602-469F-BB9D-F4241F188524/
</code></pre>
<p>The app requests <code>/remote.php/dav/calendars/jdoe/</code> instead. Authentication
succeeds, no error is surfaced, and the account simply shows <strong>zero calendars</strong>.
This is silent, which makes it hard to diagnose from the user side.</p>
<h2>Reproduction</h2>
<ol>
<li>Nextcloud instance with the LDAP/AD user backend, <em>Internal Username</em> left empty</li>
<li>Log into the app with the AD login name and an app password</li>
<li>Login succeeds, calendar list is empty</li>
</ol>
<p>Confirmed against the server with <code>curl</code> — the calendars exist and are reachable,
they are just under a different path than the one the app builds:</p>
<pre><code class="language-console">$ curl -u "jdoe:APP_PASSWORD" -X PROPFIND -H "Depth: 1" \
    https://cloud.example.com/remote.php/dav/calendars/143A944C-B602-469F-BB9D-F4241F188524/
207 Multi-Status   # all calendars listed

$ curl -u "jdoe:APP_PASSWORD" -X PROPFIND -H "Depth: 1" \
    https://cloud.example.com/remote.php/dav/calendars/jdoe/
404 Not Found
</code></pre>
<p>Note the split: the <strong>login name</strong> authenticates, the <strong>UUID</strong> addresses the
resources. They are different identifiers and the app conflates them.</p>
<h2>Fix</h2>
<p>Ask the server rather than guessing, using the standard discovery sequence:</p>
<ol>
<li><code>PROPFIND /remote.php/dav/</code> (Depth 0) for <code>&lt;d:current-user-principal&gt;</code> — <a href="https://www.rfc-editor.org/rfc/rfc5397">RFC 5397</a></li>
<li><code>PROPFIND &lt;principal&gt;</code> (Depth 0) for <code>&lt;cal:calendar-home-set&gt;</code> — <a href="https://www.rfc-editor.org/rfc/rfc4791#section-6.2.1">RFC 4791 §6.2.1</a></li>
<li>Use the last path segment of the calendar home as <code>davUserId</code></li>
</ol>
<p>This is what DAVx⁵, Thunderbird and iOS Calendar do, and it is backend-agnostic:
the server reports its own identifiers, so LDAP, SAML, OIDC and database accounts
are all handled by the same code path.</p>
<p>Href extraction matches on XML local names, since namespace prefixes are
server-defined (Nextcloud emits <code>d:</code> and <code>cal:</code>, other servers differ).</p>
<h3>Backwards compatibility</h3>
<p>Deliberately conservative — no behaviour change for accounts that work today:</p>

Situation | Result
-- | --
Database backend (davUserId == login) | discovery returns the login name, unchanged
LDAP/AD backend | discovery returns the UUID — fixed
calendar-home-set not advertised | falls back to the principal slug
current-user-principal not advertised | falls back to params.username (previous behaviour)
Non-207 / error response | throws as before


<p>Cost is one extra <code>PROPFIND</code> at login only. No change to the sync path.</p>
<h2>Testing</h2>
<p>Parsing verified against real Nextcloud responses for: an LDAP account (UUID
returned correctly), a database account (login name returned unchanged), and a
server advertising neither property (falls back without throwing).</p>
<p>Happy to add unit tests under <code>__tests__/</code> covering these three cases if you'd
like them in this PR — let me know the fixture style you prefer.</p></body></html><!--EndFragment-->
</body>
</html># fix(caldav): discover the DAV user id instead of assuming it equals the login name

Closes #52

## Problem

`validateCredentials()` returns `{ davUserId: params.username }`, and `calUrl()`
builds every calendar path from that value:

```ts
`${account.baseUrl}/remote.php/dav/calendars/${encodeURIComponent(account.davUserId)}/${path}`
```

This assumes the login name and the DAV user id are the same. That holds for the
default database backend, but **not** for external user backends.

With LDAP / Active Directory, Nextcloud derives the internal username from the
directory UUID unless an explicit *Internal Username* attribute is configured —
and auto-detecting the UUID attribute is the documented default behaviour
(see the [[LDAP admin manual](https://docs.nextcloud.com/server/stable/admin_manual/configuration_user/user_auth_ldap.html)](https://docs.nextcloud.com/server/stable/admin_manual/configuration_user/user_auth_ldap.html)).

So a user logging in as `jdoe` owns calendars under:

```
/remote.php/dav/calendars/143A944C-B602-469F-BB9D-F4241F188524/
```

The app requests `/remote.php/dav/calendars/jdoe/` instead. Authentication
succeeds, no error is surfaced, and the account simply shows **zero calendars**.
This is silent, which makes it hard to diagnose from the user side.

## Reproduction

1. Nextcloud instance with the LDAP/AD user backend, *Internal Username* left empty
2. Log into the app with the AD login name and an app password
3. Login succeeds, calendar list is empty

Confirmed against the server with `curl` — the calendars exist and are reachable,
they are just under a different path than the one the app builds:

```console
$ curl -u "jdoe:APP_PASSWORD" -X PROPFIND -H "Depth: 1" \
    https://cloud.example.com/remote.php/dav/calendars/143A944C-B602-469F-BB9D-F4241F188524/
207 Multi-Status   # all calendars listed

$ curl -u "jdoe:APP_PASSWORD" -X PROPFIND -H "Depth: 1" \
    https://cloud.example.com/remote.php/dav/calendars/jdoe/
404 Not Found
```

Note the split: the **login name** authenticates, the **UUID** addresses the
resources. They are different identifiers and the app conflates them.

## Fix

Ask the server rather than guessing, using the standard discovery sequence:

1. `PROPFIND /remote.php/dav/` (Depth 0) for `<d:current-user-principal>` — [[RFC 5397](https://www.rfc-editor.org/rfc/rfc5397)](https://www.rfc-editor.org/rfc/rfc5397)
2. `PROPFIND <principal>` (Depth 0) for `<cal:calendar-home-set>` — [[RFC 4791 §6.2.1](https://www.rfc-editor.org/rfc/rfc4791#section-6.2.1)](https://www.rfc-editor.org/rfc/rfc4791#section-6.2.1)
3. Use the last path segment of the calendar home as `davUserId`

This is what DAVx⁵, Thunderbird and iOS Calendar do, and it is backend-agnostic:
the server reports its own identifiers, so LDAP, SAML, OIDC and database accounts
are all handled by the same code path.

Href extraction matches on XML local names, since namespace prefixes are
server-defined (Nextcloud emits `d:` and `cal:`, other servers differ).

### Backwards compatibility

Deliberately conservative — no behaviour change for accounts that work today:

| Situation | Result |
|---|---|
| Database backend (`davUserId` == login) | discovery returns the login name, unchanged |
| LDAP/AD backend | discovery returns the UUID — **fixed** |
| `calendar-home-set` not advertised | falls back to the principal slug |
| `current-user-principal` not advertised | falls back to `params.username` (previous behaviour) |
| Non-207 / error response | throws as before |

Cost is one extra `PROPFIND` at login only. No change to the sync path.

## Testing

Parsing verified against real Nextcloud responses for: an LDAP account (UUID
returned correctly), a database account (login name returned unchanged), and a
server advertising neither property (falls back without throwing).

Happy to add unit tests under `__tests__/` covering these three cases if you'd
like them in this PR — let me know the fixture style you prefer.
---

*Disclosure: this patch was written with AI assistance (Claude). I diagnosed the
issue on my own Nextcloud + Active Directory instance and verified the behaviour
against my server with curl before and after the change.*