### PR TITLE
fix: CalDAV URLs with Nextcloud in a subdirectory

### DIFF
--- a/__tests__/api/caldav.test.ts
+++ b/__tests__/api/caldav.test.ts
@@ -111,6 +111,39 @@ describe('syncCollection', () => {
     expect(res.reset).toBe(false);
   });
 
+  it('does not duplicate the subfolder path when Nextcloud is installed in a subdirectory', async () => {
+    const subAccount: Account = {
+      id: 'acc-2',
+      displayName: 'Subfolder',
+      baseUrl: 'https://cloud.example.com/nextcloud',
+      username: 'john',
+      appPassword: 'xxxx',
+      davUserId: 'john',
+    };
+    const subCal: CalendarMeta = {
+      id: 'cal-sub',
+      accountId: 'acc-2',
+      displayName: 'Personal',
+      color: '#1976d2',
+      ctag: '1',
+      url: 'https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/',
+      slug: 'personal',
+    };
+    const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/nextcloud/remote.php/dav/calendars/john/personal/a.ics</d:href>
+    <d:propstat><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:sync-token>http://sabre.io/ns/sync/1</d:sync-token>
+</d:multistatus>`;
+    mockFetch.mockResolvedValue({ status: 207, text: async () => xml });
+
+    const res = await syncCollection(subAccount, subCal, undefined);
+
+    expect(res.changed).toEqual(['https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/a.ics']);
+  });
+
   it('sends an empty sync-token on first run (no stored token)', async () => {
     mockFetch.mockResolvedValue({
       status: 207,

--- a/src/services/nextcloud/caldav.ts
+++ b/src/services/nextcloud/caldav.ts
@@ -11,6 +11,10 @@ function calUrl(account: Account, path = ''): string {
   return `${account.baseUrl}/remote.php/dav/calendars/${encodeURIComponent(account.davUserId)}/${path}`;
 }
 
+function absUrl(account: Pick<Account, 'baseUrl'>, pathOrHref: string): string {
+  return pathOrHref.startsWith('http') ? pathOrHref : new URL(pathOrHref, account.baseUrl).href;
+}
+
 function extractSlug(url: string): string {
   const slug = url.replace(/\/$/, '').split('/').pop() ?? '';
   try {
@@ -143,7 +147,7 @@ export async function syncCollection(
   for (const chunk of splitResponses(xml)) {
     const hrefMatch = chunk.match(/<d:href>([^<]+)<\/d:href>/);
     if (!hrefMatch) continue;
-    const abs = `${account.baseUrl}${hrefMatch[1]}`;
+    const abs = absUrl(account, hrefMatch[1]);
     if (/<d:status>[^<]*\b404\b/.test(chunk)) deleted.push(abs);
     else changed.push(abs);
   }
@@ -189,7 +193,7 @@ export async function fetchCalendars(account: Account): Promise<CalendarMeta[]> 
     const hrefMatch = chunk.match(/<d:href>([^<]+)<\/d:href>/);
     if (!hrefMatch) continue;
     const path = hrefMatch[1];
-    const calFullUrl = `${account.baseUrl}${path}`;
+    const calFullUrl = absUrl(account, path);
     const slug = extractSlug(path);
 
     const displayNameMatch = chunk.match(/<d:displayname>([^<]*)<\/d:displayname>/);
@@ -283,7 +287,7 @@ export async function fetchEvents(
     const hrefMatch = chunk.match(/<d:href>([^<]+)<\/d:href>/);
     const dataMatch = chunk.match(/<cal:calendar-data[^>]*>([\s\S]*?)<\/cal:calendar-data>/);
     if (dataMatch?.[1] && hrefMatch?.[1]) {
-      const href = `${account.baseUrl}${hrefMatch[1]}`;
+      const href = absUrl(account, hrefMatch[1]);
       items.push({ ics: decodeXmlEntities(dataMatch[1].trim()), href });
     }
   }
@@ -417,7 +421,7 @@ export async function fetchEventsByHrefs(
       const hrefMatch = chunk.match(/<d:href>([^<]+)<\/d:href>/);
       const dataMatch = chunk.match(/<cal:calendar-data[^>]*>([\s\S]*?)<\/cal:calendar-data>/);
       if (dataMatch?.[1] && hrefMatch?.[1]) {
-        items.push({ ics: decodeXmlEntities(dataMatch[1].trim()), href: `${account.baseUrl}${hrefMatch[1]}` });
+        items.push({ ics: decodeXmlEntities(dataMatch[1].trim()), href: absUrl(account, hrefMatch[1]) });
       }
     }
 


### PR DESCRIPTION
## Problem

When Nextcloud is installed in a subdirectory (e.g. `https://host/nextcloud`), the app cannot sync calendars: it requests `/nextcloud/nextcloud/remote.php/dav/calendars/...` (the subfolder is duplicated) and gets HTTP 405, so the calendar list and events never load.

The calendar `href`s returned by a `PROPFIND` on the calendar home are already absolute server paths that include the Nextcloud base path. The code unconditionally prepended `account.baseUrl`, producing a duplicated path.

## Fix

Resolve server-relative `href`s against `account.baseUrl` with the `URL` constructor instead of naive string concatenation (new `absUrl` helper). Applied in `fetchCalendars`, `syncCollection`, `fetchEvents` and `fetchEventsByHrefs`. Behavior for root-level installs is unchanged.

## Test

Added a regression test covering a Nextcloud install under `/nextcloud`.

All 228 tests pass.