### PR TITLE
fix: drawer settings button needed two taps to open Settings

### DIFF
--- a/app/(tabs)/calendar/index.tsx
+++ b/app/(tabs)/calendar/index.tsx
@@ -234,7 +234,7 @@ export default function CalendarScreen() {
         hiddenCalendarIds={hiddenCalendarIds}
         toggleCalendarVisibility={toggleCalendarVisibility}
         onClose={drawer.closeDrawer}
-        onNavigateSettings={() => { drawer.closeDrawer(); router.push('/(tabs)/settings'); }}
+        onNavigateSettings={() => { router.push('/(tabs)/settings'); drawer.closeDrawer(); }}
       />
     </ViewContainer>
   );

--- a/src/features/calendar/hooks/useCalendarDrawer.ts
+++ b/src/features/calendar/hooks/useCalendarDrawer.ts
@@ -12,7 +12,7 @@ export function useCalendarDrawer() {
     drawerAnimation.current?.stop();
     setDrawerOpen(true);
     drawerAnimation.current = Animated.parallel([
-      Animated.spring(drawerAnim, { toValue: 0, useNativeDriver: true, damping: 20, stiffness: 200, mass: 0.8 }),
+      Animated.timing(drawerAnim, { toValue: 0, duration: 250, useNativeDriver: true }),
       Animated.timing(overlayAnim, { toValue: 1, duration: 250, useNativeDriver: true }),
     ]);
     drawerAnimation.current.start();
@@ -20,11 +20,12 @@ export function useCalendarDrawer() {
 
   const closeDrawer = useCallback(() => {
     drawerAnimation.current?.stop();
+    setDrawerOpen(false);
     drawerAnimation.current = Animated.parallel([
-      Animated.spring(drawerAnim, { toValue: -DRAWER_WIDTH, useNativeDriver: true, damping: 20, stiffness: 200, mass: 0.8 }),
+      Animated.timing(drawerAnim, { toValue: -DRAWER_WIDTH, duration: 250, useNativeDriver: true }),
       Animated.timing(overlayAnim, { toValue: 0, duration: 200, useNativeDriver: true }),
     ]);
-    drawerAnimation.current.start(({ finished }) => { if (finished) setDrawerOpen(false); });
+    drawerAnimation.current.start();
   }, [drawerAnim, overlayAnim]);
 
   return { drawerOpen, drawerAnim, overlayAnim, openDrawer, closeDrawer };


### PR DESCRIPTION
Fixes the calendar drawer's "Manage accounts" button requiring **two taps** to open Settings on Android.

https://github.com/user-attachments/assets/6058fd76-fa65-442c-a1a2-e862a1812126

