### PR TITLE
fix: build CalDAV URLs correctly when Nextcloud is in a subdirectory

### DIFF
--- a/__tests__/api/caldav.test.ts
+++ b/__tests__/api/caldav.test.ts
@@ -234,3 +234,80 @@ describe('fetchCalendars', () => {
     expect(cal.sourceUrl).toBe('https://ics.example.com/f?a=1&b=2');
   });
 });
+
+describe('Nextcloud installed in a subdirectory', () => {
+  const subAccount: Account = {
+    id: 'acc-2',
+    displayName: 'Subfolder',
+    baseUrl: 'https://cloud.example.com/nextcloud',
+    username: 'john',
+    appPassword: 'xxxx',
+    davUserId: 'john',
+  };
+  const subCal: CalendarMeta = {
+    id: 'cal-sub',
+    accountId: 'acc-2',
+    displayName: 'Personal',
+    color: '#1976d2',
+    ctag: '1',
+    url: 'https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/',
+    slug: 'personal',
+  };
+
+  it('syncCollection does not duplicate the subfolder in changed/deleted hrefs', async () => {
+    const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>/nextcloud/remote.php/dav/calendars/john/personal/a.ics</d:href>
+    <d:propstat><d:status>HTTP/1.1 200 OK</d:status></d:propstat>
+  </d:response>
+  <d:response>
+    <d:href>/nextcloud/remote.php/dav/calendars/john/personal/gone.ics</d:href>
+    <d:status>HTTP/1.1 404 Not Found</d:status>
+  </d:response>
+  <d:sync-token>http://sabre.io/ns/sync/1</d:sync-token>
+</d:multistatus>`;
+    mockFetch.mockResolvedValue({ status: 207, text: async () => xml });
+
+    const res = await syncCollection(subAccount, subCal, undefined);
+
+    expect(res.changed).toEqual(['https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/a.ics']);
+    expect(res.deleted).toEqual(['https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/gone.ics']);
+  });
+
+  it('fetchCalendars builds the calendar url without duplicating the subfolder', async () => {
+    const xml = `<?xml version="1.0"?>
+<d:multistatus xmlns:d="DAV:" xmlns:cs="http://calendarserver.org/ns/" xmlns:c="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>/nextcloud/remote.php/dav/calendars/john/personal/</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:resourcetype><d:collection/><c:calendar/></d:resourcetype>
+        <d:displayname>Personal</d:displayname>
+        <cs:getctag>42</cs:getctag>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`;
+    mockFetch.mockResolvedValue({ status: 207, text: async () => xml });
+
+    const [cal] = await fetchCalendars(subAccount);
+
+    expect(cal.url).toBe('https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/');
+  });
+
+  it('fetchEventsByHrefs builds event hrefs without duplicating the subfolder', async () => {
+    const ics = 'BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:a\r\nSUMMARY:a\r\nDTSTART:20260615T090000Z\r\nDTEND:20260615T100000Z\r\nEND:VEVENT\r\nEND:VCALENDAR';
+    const xml = `<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav"><d:response><d:href>/nextcloud/remote.php/dav/calendars/john/personal/a.ics</d:href><d:propstat><d:prop><cal:calendar-data>${ics}</cal:calendar-data></d:prop></d:propstat></d:response></d:multistatus>`;
+    mockFetch.mockResolvedValue({ status: 207, text: async () => xml });
+
+    const events = await fetchEventsByHrefs(
+      subAccount, subCal,
+      ['https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/a.ics'],
+      new Date('2026-01-01T00:00:00Z'), new Date('2026-12-31T00:00:00Z'),
+    );
+
+    expect(events[0].href).toBe('https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/a.ics');
+  });
+});

--- a/src/services/nextcloud/caldav.ts
+++ b/src/services/nextcloud/caldav.ts
@@ -11,6 +11,10 @@ function calUrl(account: Account, path = ''): string {
   return `${account.baseUrl}/remote.php/dav/calendars/${encodeURIComponent(account.davUserId)}/${path}`;
 }
 
+function absUrl(account: Pick<Account, 'baseUrl'>, pathOrHref: string): string {
+  return /^https?:\/\//i.test(pathOrHref) ? pathOrHref : new URL(pathOrHref, account.baseUrl).href;
+}
+
 function extractSlug(url: string): string {
   const slug = url.replace(/\/$/, '').split('/').pop() ?? '';
   try {
@@ -143,7 +147,7 @@ export async function syncCollection(
   for (const chunk of splitResponses(xml)) {
     const hrefMatch = chunk.match(/<d:href>([^<]+)<\/d:href>/);
     if (!hrefMatch) continue;
-    const abs = `${account.baseUrl}${hrefMatch[1]}`;
+    const abs = absUrl(account, hrefMatch[1]);
     if (/<d:status>[^<]*\b404\b/.test(chunk)) deleted.push(abs);
     else changed.push(abs);
   }
@@ -189,7 +193,7 @@ export async function fetchCalendars(account: Account): Promise<CalendarMeta[]> 
     const hrefMatch = chunk.match(/<d:href>([^<]+)<\/d:href>/);
     if (!hrefMatch) continue;
     const path = hrefMatch[1];
-    const calFullUrl = `${account.baseUrl}${path}`;
+    const calFullUrl = absUrl(account, path);
     const slug = extractSlug(path);
 
     const displayNameMatch = chunk.match(/<d:displayname>([^<]*)<\/d:displayname>/);
@@ -283,7 +287,7 @@ export async function fetchEvents(
     const hrefMatch = chunk.match(/<d:href>([^<]+)<\/d:href>/);
     const dataMatch = chunk.match(/<cal:calendar-data[^>]*>([\s\S]*?)<\/cal:calendar-data>/);
     if (dataMatch?.[1] && hrefMatch?.[1]) {
-      const href = `${account.baseUrl}${hrefMatch[1]}`;
+      const href = absUrl(account, hrefMatch[1]);
       items.push({ ics: decodeXmlEntities(dataMatch[1].trim()), href });
     }
   }
@@ -416,7 +420,7 @@ export async function fetchEventsByHrefs(
       const hrefMatch = chunk.match(/<d:href>([^<]+)<\/d:href>/);
       const dataMatch = chunk.match(/<cal:calendar-data[^>]*>([\s\S]*?)<\/cal:calendar-data>/);
       if (dataMatch?.[1] && hrefMatch?.[1]) {
-        items.push({ ics: decodeXmlEntities(dataMatch[1].trim()), href: `${account.baseUrl}${hrefMatch[1]}` });
+        items.push({ ics: decodeXmlEntities(dataMatch[1].trim()), href: absUrl(account, hrefMatch[1]) });
       }
     }
 


### PR DESCRIPTION
Resolve server-relative hrefs against baseUrl with the URL constructor instead of naive concatenation, avoiding a duplicated webroot on sub-directory installs. Adds subfolder regression tests.

@ShiMMyTo