### PR TITLE
fix: subscribed calendars with webcal:// URLs and react-native-screens bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-native-nitro-modules": "^0.36.1",
     "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",
-    "react-native-screens": "4.25.2",
+    "react-native-screens": "~4.26.0",
     "react-native-svg": "15.15.4",
     "react-native-worklets": "0.10.0",
     "react-native-worklets-core": "^1.6.3",

--- a/src/services/nextcloud/caldav.ts
+++ b/src/services/nextcloud/caldav.ts
@@ -325,7 +325,8 @@ export async function fetchEvents(
     end: Date
 ): Promise<CalendarEvent[]> {
     if (calendar.isSubscribed && calendar.sourceUrl) {
-        const r = await trustedFetch(calendar.sourceUrl, { timeoutMs: 20000 });
+        const sourceUrl = calendar.sourceUrl.replace(/^webcals?:\/\//i, 'https://');
+        const r = await trustedFetch(sourceUrl, { timeoutMs: 20000 });
         if (!r.ok) throw new Error(`fetchSubscribed HTTP ${r.status}`);
         const icsText = await r.text();
         const parsed = await parseIcsObjectsAsync(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8591,7 +8591,7 @@ __metadata:
     react-native-nitro-modules: "npm:^0.36.1"
     react-native-reanimated: "npm:4.5.0"
     react-native-safe-area-context: "npm:~5.7.0"
-    react-native-screens: "npm:4.25.2"
+    react-native-screens: "npm:~4.26.0"
     react-native-svg: "npm:15.15.4"
     react-native-worklets: "npm:0.10.0"
     react-native-worklets-core: "npm:^1.6.3"
@@ -9562,19 +9562,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-screens@npm:4.25.2":
-  version: 4.25.2
-  resolution: "react-native-screens@npm:4.25.2"
-  dependencies:
-    react-freeze: "npm:^1.0.0"
-    warn-once: "npm:^0.1.0"
-  peerDependencies:
-    react: "*"
-    react-native: ">=0.82.0"
-  checksum: 10c0/b1f155830e57c36e8ca60831f4b22079cd311f0e36f7c4465ff4094f9dec18e66cef2321a4ff8944aac51ead437720585080f1f4b2956106099a9ea7d9745d00
-  languageName: node
-  linkType: hard
-
 "react-native-screens@npm:^4.26.0":
   version: 4.27.0
   resolution: "react-native-screens@npm:4.27.0"
@@ -9585,6 +9572,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/357674b881189ff8933f457acadbfc3030a376d0ccdfb4b6005462aabbf38287d4d0f39a301cb94c45df6c2e09be28bcfc4d71298c8d34b8ac87ebe639e46ff9
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:~4.26.0":
+  version: 4.26.2
+  resolution: "react-native-screens@npm:4.26.2"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/3cdc702d8e21c63331e306a2b971307d5d9e13df52d94f435c5bb8d5dcf09fed00f4ef788e85ba87fae1ba5b155f4cdc2ee177a70f1f512adff73f94eef844d1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR fixes the empty calendar view reported when a Nextcloud account has subscribed calendars whose source URL uses the `webcal://` protocol.

### Changes

- `src/services/nextcloud/caldav.ts`: normalize `webcal://` and `webcals://` to `https://` before fetching subscribed calendar ICS data. React Native's `fetch` / `TlsTrust` do not understand the `webcal` scheme and throw `MalformedURLException: unknown protocol: webcal`, causing `syncEvents` to fail for the whole set of calendars.
- `package.json` + `yarn.lock`: bump `react-native-screens` from `4.25.2` to `~4.26.0` to match Expo Router 57's peer requirement and avoid the Fabric / `RNSModule` startup crash on Android.

### Test plan

- [x] Built and ran the Android dev client on a Pixel 7 API 36 emulator.
- [x] Connected to a Nextcloud 30 instance at `https://cloud.sipc-cgt.fr`.
- [x] Confirmed 12 calendars sync and ~145 events load.
- [x] Verified events display in Month, Week, Day, and Agenda views.

### Notes

The `webcal://` calendar (`PSG`) previously made `settleAllOrThrow` reject the entire `syncEvents` call, so no events were stored in WatermelonDB. After the URL normalization, the remaining 11 calendars sync successfully and events render.