### PR TITLE
fix(security): restrict cleartext traffic and remove user-trusted certificates

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
       <data android:scheme="https"/>
     </intent>
   </queries>
-  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true" android:enableOnBackInvokedCallback="false" android:fullBackupContent="@xml/secure_store_backup_rules" android:dataExtractionRules="@xml/secure_store_data_extraction_rules" android:networkSecurityConfig="@xml/network_security_config" android:usesCleartextTraffic="true">
+  <application android:name=".MainApplication" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:roundIcon="@mipmap/ic_launcher_round" android:allowBackup="true" android:theme="@style/AppTheme" android:supportsRtl="true" android:enableOnBackInvokedCallback="false" android:fullBackupContent="@xml/secure_store_backup_rules" android:dataExtractionRules="@xml/secure_store_data_extraction_rules" android:networkSecurityConfig="@xml/network_security_config">
     <meta-data android:name="expo.modules.updates.ENABLED" android:value="false"/>
     <meta-data android:name="expo.modules.updates.ENABLE_BSDIFF_PATCH_SUPPORT" android:value="true"/>
     <meta-data android:name="expo.modules.updates.EXPO_UPDATES_CHECK_ON_LAUNCH" android:value="ALWAYS"/>

--- a/app.config.ts
+++ b/app.config.ts
@@ -38,7 +38,8 @@ const config: ExpoConfig = {
             LSApplicationQueriesSchemes: ['nextcloudtalk'],
             ITSAppUsesNonExemptEncryption: false,
             NSAppTransportSecurity: {
-                NSAllowsArbitraryLoads: true,
+                NSAllowsArbitraryLoads: false,
+                NSAllowsLocalNetworking: true,
             },
         },
         entitlements: {
@@ -68,14 +69,6 @@ const config: ExpoConfig = {
     owner: 'soluce',
 
     plugins: [
-        [
-            'expo-build-properties',
-            {
-                android: {
-                    usesCleartextTraffic: true,
-                },
-            },
-        ],
         './plugins/withAndroidNetworkSecurityConfig',
         '@morrowdigital/watermelondb-expo-plugin',
         '@react-native-community/datetimepicker',

--- a/plugins/withAndroidNetworkSecurityConfig.js
+++ b/plugins/withAndroidNetworkSecurityConfig.js
@@ -9,7 +9,6 @@ const NSC_CONTENTS = `<?xml version="1.0" encoding="utf-8"?>
     <base-config cleartextTrafficPermitted="true">
         <trust-anchors>
             <certificates src="system" />
-            <certificates src="user" />
         </trust-anchors>
     </base-config>
 </network-security-config>


### PR DESCRIPTION
## Summary
Closes #199

Restricts the app's overly permissive network configuration:
- iOS: `NSAllowsArbitraryLoads: false` + `NSAllowsLocalNetworking: true`
- Android: removes `<certificates src="user" />` from the network security config
- Removes `usesCleartextTraffic: true` from `expo-build-properties`, so the `network_security_config` plugin is the single source of truth.

## What changed
- `app.config.ts`
  - `NSAllowsArbitraryLoads: false` (was `true`)
  - `NSAllowsLocalNetworking: true` (new)
  - Removed the `expo-build-properties` entry that set `android.usesCleartextTraffic: true`
- `plugins/withAndroidNetworkSecurityConfig.js`
  - Removed `<certificates src="user" />`; only system CAs are trusted by default
- `android/app/src/main/AndroidManifest.xml`
  - Removed `android:usesCleartextTraffic="true"` (generated by prebuild)

## Why
The previous config allowed:
1. Cleartext HTTP to any host on iOS (ATS disabled).
2. User-installed certificates to be trusted on Android, enabling MitM if a malicious root CA is installed.

This change keeps local HTTP Nextcloud instances working on iOS while blocking public HTTP, and removes the user CA trust vector on Android.

## Testing
- [x] `yarn tsc --noEmit` passes
- [x] `yarn jest --ci` passes (68 suites, 591 tests)
- [x] `npx expo prebuild --platform android --clean` + `yarn android` builds successfully
- [x] APK inspected with `aapt`: `network_security_config.xml` only contains `<certificates src="system" />`
- [x] iOS `Info.plist` generated by prebuild: `NSAllowsArbitraryLoads = false`, `NSAllowsLocalNetworking = true`
- [x] App launches and displays the calendar view on Android emulator

## Risk
- Users who relied on a user-installed CA for their Nextcloud cert will need to use the in-app certificate trust flow instead (which the app already supports).
- iOS users with a public HTTP-only Nextcloud server will be blocked; this is an intentional security improvement.
- Android users with HTTP-only servers are unaffected (`cleartextTrafficPermitted` stays `true` for now).