### PR TITLE
fix(sync): do not accept empty sync-token

### DIFF
--- a/__tests__/api/caldav.test.ts
+++ b/__tests__/api/caldav.test.ts
@@ -121,6 +121,16 @@ describe('syncCollection', () => {
     expect(body).toContain('<d:sync-token></d:sync-token>');
   });
 
+  it('returns undefined newToken when server sends an empty sync-token', async () => {
+    mockFetch.mockResolvedValue({
+      status: 207,
+      text: async () => `<d:multistatus xmlns:d="DAV:"><d:response><d:href>/p/a.ics</d:href><d:propstat><d:status>HTTP/1.1 200 OK</d:status></d:propstat></d:response><d:sync-token></d:sync-token></d:multistatus>`,
+    });
+    const res = await syncCollection(account, cal, 't0');
+    expect(res.newToken).toBeUndefined();
+    expect(res.reset).toBe(false);
+  });
+
   it('signals reset on 507 (invalid/expired token)', async () => {
     mockFetch.mockResolvedValue({ status: 507, text: async () => '' });
     const res = await syncCollection(account, cal, 'stale');

--- a/src/database/sync.ts
+++ b/src/database/sync.ts
@@ -281,7 +281,7 @@ export async function syncCalendarDelta(account: Account, calendar: CalendarMeta
 
     if (row) {
       ops.push(row.prepareUpdate((r: Calendar) => {
-        r.syncToken = result.newToken || r.syncToken;
+        r.syncToken = result.newToken ?? r.syncToken;
         r.expandedCenter = now.getTime();
       }));
     }

--- a/src/services/nextcloud/caldav.ts
+++ b/src/services/nextcloud/caldav.ts
@@ -116,7 +116,7 @@ export async function validateCredentials(params: {
 export interface SyncCollectionResult {
   changed: string[];
   deleted: string[];
-  newToken: string;
+  newToken: string | undefined;
   reset: boolean;
 }
 
@@ -139,7 +139,7 @@ export async function syncCollection(
   });
 
   if (res.status === 507 || res.status === 403 || res.status === 409) {
-    return { changed: [], deleted: [], newToken: '', reset: true };
+    return { changed: [], deleted: [], newToken: undefined, reset: true };
   }
   if (res.status !== 207) throw new Error(`syncCollection HTTP ${res.status}`);
 
@@ -156,7 +156,8 @@ export async function syncCollection(
   }
 
   const tokenMatch = xml.match(/<d:sync-token>([^<]*)<\/d:sync-token>/);
-  return { changed, deleted, newToken: tokenMatch?.[1]?.trim() ?? '', reset: false };
+  const newToken = tokenMatch?.[1]?.trim() || undefined;
+  return { changed, deleted, newToken, reset: false };
 }
 
 export async function fetchCalendars(account: Account): Promise<CalendarMeta[]> {


### PR DESCRIPTION
## Summary
Closes #204

Tightens sync-token handling so an empty `<d:sync-token/>` returned by the server is not treated as a valid token.

## What changed
- `src/services/nextcloud/caldav.ts`
  - `SyncCollectionResult.newToken` is now `string | undefined`.
  - `syncCollection` returns `newToken: undefined` for empty or missing sync-token elements.
  - Reset case (`507/403/409`) returns `newToken: undefined`.
- `src/database/sync.ts`
  - Uses `result.newToken ?? r.syncToken` to keep the stored token when no valid new token is provided.
- `__tests__/api/caldav.test.ts`
  - Added a test for the empty `<d:sync-token/>` response.

## Testing
- [x] `yarn tsc --noEmit` passes
- [x] `yarn jest --ci` passes (68 suites, 592 tests)
- [x] `npx jest __tests__/api/caldav.test.ts __tests__/database/syncCalendarDelta.test.ts --ci` passes
- [x] App launches and displays calendar on Android emulator

## Risk
Very low. The existing `||` fallback already prevented empty strings from being stored, but this change makes the contract explicit and type-safe.