### PR TITLE
fix(sync): harden anti-deletion guard for partial multiget

### DIFF
--- a/__tests__/database/syncCalendarDelta.test.ts
+++ b/__tests__/database/syncCalendarDelta.test.ts
@@ -100,6 +100,40 @@ describe('syncCalendarDelta — non-destructive guards', () => {
     existing.forEach((r) => expect(r.prepareMarkAsDeleted).not.toHaveBeenCalled());
   });
 
+  it('does NOT delete when a full sync parses fewer events than expected', async () => {
+    mockSyncCollection.mockResolvedValue({ changed: ['h1', 'h2', 'h3'], deleted: [], newToken: 't2', reset: false });
+    mockFetchByHrefs.mockResolvedValue([evt('h1')]);
+    const h1 = makeRow('h1');
+    const h2 = makeRow('h2');
+    const h3 = makeRow('h3');
+    const { db, batch, prepareCreate } = makeDb({ calendarRow: noTokenRow(), eventRows: [h1, h2, h3] });
+    mockGetDb.mockReturnValue(db);
+
+    await syncCalendarDelta(account, calendar);
+
+    expect(batch).not.toHaveBeenCalled();
+    expect(h1.prepareMarkAsDeleted).not.toHaveBeenCalled();
+    expect(h2.prepareMarkAsDeleted).not.toHaveBeenCalled();
+    expect(h3.prepareMarkAsDeleted).not.toHaveBeenCalled();
+    expect(prepareCreate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT delete when a delta sync parses fewer events than expected', async () => {
+    mockSyncCollection.mockResolvedValue({ changed: ['h1', 'h2'], deleted: ['h3'], newToken: 't2', reset: false });
+    mockFetchByHrefs.mockResolvedValue([evt('h1')]);
+    const h1 = makeRow('h1');
+    const h2 = makeRow('h2');
+    const h3 = makeRow('h3');
+    const { db, batch, prepareCreate } = makeDb({ calendarRow: tokenRow(), eventRows: [h1, h2, h3] });
+    mockGetDb.mockReturnValue(db);
+
+    await syncCalendarDelta(account, calendar);
+
+    expect(batch).not.toHaveBeenCalled();
+    [h1, h2, h3].forEach((r) => expect(r.prepareMarkAsDeleted).not.toHaveBeenCalled());
+    expect(prepareCreate).not.toHaveBeenCalled();
+  });
+
   it('does NOT delete existing rows when a full sync enumerates zero members (untrusted empty)', async () => {
     mockSyncCollection.mockResolvedValue({ changed: [], deleted: [], newToken: 't2', reset: false });
     mockFetchByHrefs.mockResolvedValue([]);

--- a/src/database/sync.ts
+++ b/src/database/sync.ts
@@ -247,7 +247,10 @@ export async function syncCalendarDelta(account: Account, calendar: CalendarMeta
   );
   const fetchedHrefs = new Set(fetched.map((e) => e.href));
 
-  if (fullSync && result.changed.length > 0 && fetched.length === 0) {
+  if (result.changed.length > 0 && fetched.length !== result.changed.length) {
+    console.warn(
+      `[syncCalendarDelta] multiget returned ${fetched.length}/${result.changed.length} events; skipping write`
+    );
     return;
   }
 


### PR DESCRIPTION
## Summary
Closes #206

Extends the incomplete anti-deletion guard in `syncCalendarDelta` so it protects both full and delta syncs when the multiget is incomplete.

## What changed
- `src/database/sync.ts`
  - The guard now aborts whenever `result.changed.length !== fetched.length` (regardless of full or delta sync).
  - Added a warning log explaining how many events were returned vs expected.
- `__tests__/database/syncCalendarDelta.test.ts`
  - Added tests for full sync and delta sync with a partial multiget result (fewer events returned than expected).

## Testing
- [x] `yarn tsc --noEmit` passes
- [x] `yarn jest --ci` passes (68 suites, 594 tests)
- [x] `npx jest __tests__/database/syncCalendarDelta.test.ts --ci` passes

## Risk
Very low. Existing tests already cover the full-sync zero-events case and continue to pass. The new guard only skips writes when the multiget is incomplete, which is the safest behaviour.