### PR TITLE
chore: remove unused imports and parameters

### DIFF
--- a/__tests__/components/TimeGridView.test.tsx
+++ b/__tests__/components/TimeGridView.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { render as rtlRender } from '@testing-library/react-native';
-import { Gesture } from 'react-native-gesture-handler';
+
 import type { SharedValue } from 'react-native-reanimated';
 import { ThemeWrapper } from '../helpers/theme';
 import { TimeGridView } from '@/features/calendar/components/TimeGridView';

--- a/__tests__/features/widget/core.test.ts
+++ b/__tests__/features/widget/core.test.ts
@@ -1,5 +1,5 @@
 import { buildAgendaSnapshot, buildAgendaTimeline } from '@/features/widget/core/agendaSnapshot';
-import { selectOngoingEvent, eventProgress, formatRemaining, remainingMinutes, displayLocation, shouldClearLiveEvent, meetingProvider } from '@/features/widget/core/liveEvent';
+import { selectOngoingEvent, eventProgress, formatRemaining, remainingMinutes } from '@/features/widget/core/liveEvent';
 import type { CalendarEvent } from '@/types';
 
 function ev(partial: Partial<CalendarEvent> & { dtstart: Date; dtend: Date }): CalendarEvent {

--- a/app/event/[uid].tsx
+++ b/app/event/[uid].tsx
@@ -19,7 +19,7 @@ import {
   SectionHeader, Avatar, Spinner, ScreenHeader,
   IconButton,
 } from '@/ui/components';
-import type { CalendarEvent, RecurrenceEditScope } from '@/types';
+import type { RecurrenceEditScope } from '@/types';
 import { askRecurrenceScope, type RecurrenceScopeStrings } from '@/features/event/recurrenceScope';
 import { decideMoveEventScope } from '@/features/calendar/utils/moveEventScope';
 import {

--- a/src/features/calendar/components/AgendaView.tsx
+++ b/src/features/calendar/components/AgendaView.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
+import { memo, useRef, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
 import {
   View, Text, SectionList, TouchableOpacity, StyleSheet,
 } from 'react-native';
@@ -119,7 +119,7 @@ export interface AgendaViewHandle {
 
 
 const AgendaViewImpl = forwardRef<AgendaViewHandle, Props>(function AgendaView(
-  { events, date, onPressEvent, onPressCell, onVisibleDateChange }, ref
+  { events, onPressEvent, onPressCell, onVisibleDateChange }, ref
 ) {
   const theme = useTheme();
   const listRef = useRef<SectionList<CalendarEvent, AgendaSection>>(null);

--- a/src/features/widget/surfaces/homeWidget/homeWidget.ios.tsx
+++ b/src/features/widget/surfaces/homeWidget/homeWidget.ios.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Appearance } from 'react-native';
 import { HStack, Link, RoundedRectangle, Text, VStack } from '@expo/ui/swift-ui';
 import { containerBackground, font, foregroundStyle, frame, padding } from '@expo/ui/swift-ui/modifiers';

--- a/src/ui/components/Select.tsx
+++ b/src/ui/components/Select.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, type ReactNode } from 'react';
+import { useRef, useState, type ReactNode } from 'react';
 import { View, Modal, Pressable, ScrollView, StyleSheet, useWindowDimensions } from 'react-native';
 import { ChevronUp, ChevronDown, Check } from 'lucide-react-native';
 import { GlassView, isLiquidGlassAvailable } from 'expo-glass-effect';

--- a/src/ui/components/Stack.tsx
+++ b/src/ui/components/Stack.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FlexAlignType, StyleProp, StyleSheet, ViewProps, ViewStyle, DimensionValue } from 'react-native';
+import { memo } from 'react';
+import { FlexAlignType, StyleProp, ViewProps, ViewStyle, DimensionValue } from 'react-native';
 import Reanimated, { LinearTransition } from 'react-native-reanimated';
 import { useTheme } from 'expo-router';
 
@@ -133,4 +133,4 @@ function Stack({
   );
 }
 
-export default React.memo(Stack);
+export default memo(Stack);


### PR DESCRIPTION
## Summary
Clean up unused locals surfaced by enabling `noUnusedLocals`.

## Changes
- Remove unused `Gesture` import in `TimeGridView` test.
- Remove unused widget helpers from `widget/core` test.
- Remove unused `CalendarEvent` type import from `app/event/[uid].tsx`.
- Remove unused `useEffect` and `date` prop from `AgendaView`.
- Remove unused `React` import from iOS home widget and `Select`.
- Import `memo` directly in `Stack` instead of `React.memo`.

## Verification
- `yarn tsc --noEmit` ✅
- `yarn jest --ci` ✅ (68 suites, 599 tests)

No functional changes.