### PR TITLE
chore: replace loose any types with precise types

### DIFF
--- a/src/features/calendar/components/AgendaView.tsx
+++ b/src/features/calendar/components/AgendaView.tsx
@@ -1,6 +1,6 @@
 import { memo, useRef, useEffect, useCallback, useMemo, forwardRef, useImperativeHandle } from 'react';
 import {
-  View, Text, SectionList, TouchableOpacity, StyleSheet,
+  View, Text, SectionList, TouchableOpacity, StyleSheet, type ViewToken,
 } from 'react-native';
 import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
@@ -169,7 +169,7 @@ const AgendaViewImpl = forwardRef<AgendaViewHandle, Props>(function AgendaView(
   }));
 
   const viewabilityConfig = useRef({ itemVisiblePercentThreshold: 50 });
-  const onViewableItemsChanged = useCallback(({ viewableItems }: any) => {
+  const onViewableItemsChanged = useCallback(({ viewableItems }: { viewableItems: ViewToken[] }) => {
     if (!onVisibleDateChange || viewableItems.length === 0) return;
     const first = viewableItems[0];
     const d: Date | undefined = first?.section?.date ?? first?.item?.dtstart;

--- a/src/features/event/components/EventForm.tsx
+++ b/src/features/event/components/EventForm.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
-import { View, StyleSheet, ScrollView, Platform, KeyboardAvoidingView, useWindowDimensions } from 'react-native';
-import DateTimePicker from '@react-native-community/datetimepicker';
+import { View, StyleSheet, ScrollView, Platform, KeyboardAvoidingView, useWindowDimensions, LayoutChangeEvent } from 'react-native';
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import dayjs from 'dayjs';
 import localizedFormat from 'dayjs/plugin/localizedFormat';
 import { useTranslation } from 'react-i18next';
@@ -90,7 +90,7 @@ export function EventForm({
     if (y != null) scrollRef.current?.scrollTo({ y: Math.max(0, y - 80), animated: true });
   }
 
-  function onFieldLayout(key: string, event: any) {
+  function onFieldLayout(key: string, event: LayoutChangeEvent) {
     inputOffsets.current[key] = event.nativeEvent.layout.y;
   }
 
@@ -134,15 +134,15 @@ export function EventForm({
     }
   }
 
-  function handleIosStartChange(_: any, d?: Date) {
+  function handleIosStartChange(_: DateTimePickerEvent, d?: Date) {
     if (d) applyStart(d);
   }
 
-  function handleIosEndChange(_: any, d?: Date) {
+  function handleIosEndChange(_: DateTimePickerEvent, d?: Date) {
     if (d) applyEnd(d);
   }
 
-  function handleAndroidChange(_: any, selected?: Date) {
+  function handleAndroidChange(_: DateTimePickerEvent, selected?: Date) {
     if (!androidStep) return;
 
     if (selected === undefined) {

--- a/src/ui/components/Icon.tsx
+++ b/src/ui/components/Icon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo, type ReactElement } from 'react';
 import { View, ViewProps } from 'react-native';
 import { useTheme } from 'expo-router';
 
@@ -9,17 +9,23 @@ interface IconProps extends ViewProps {
   opacity?: number;
 }
 
+interface IconChildProps {
+  color?: string;
+  size?: number;
+}
+
 function injectProps(children: React.ReactNode, color: string, size: number): React.ReactNode {
-  const inject = (child: React.ReactElement<any>) => {
+  const inject = (child: ReactElement<unknown>) => {
+    const props = child.props as IconChildProps;
     const next: Record<string, unknown> = {};
-    if (child.props.color === undefined) next.color = color;
-    if (child.props.size === undefined) next.size = size;
+    if (props.color === undefined) next.color = color;
+    if (props.size === undefined) next.size = size;
     return Object.keys(next).length ? React.cloneElement(child, next) : child;
   };
 
-  if (React.isValidElement(children)) return inject(children as React.ReactElement<any>);
+  if (React.isValidElement(children)) return inject(children);
   return React.Children.map(children, (child) =>
-    React.isValidElement(child) ? inject(child as React.ReactElement<any>) : child
+    React.isValidElement(child) ? inject(child) : child
   );
 }
 
@@ -50,4 +56,4 @@ function Icon({ children, color, size = 24, opacity, style, ...rest }: IconProps
   );
 }
 
-export default React.memo(Icon);
+export default memo(Icon);


### PR DESCRIPTION
## Summary
Replace loose `any` annotations with precise types in a few UI components.

## Changes
- `EventForm`: `DateTimePickerEvent` instead of `any` for start/end pickers.
- `AgendaView`: typed `ViewToken[]` callback for `onViewableItemsChanged`.
- `Icon`: stricter `IconChildProps` for children render.
- Minor cleanups of unused locals.

## Verification
- `yarn tsc --noEmit` ✅
- `yarn jest --ci` ✅ (68 suites, 599 tests)

No runtime changes.