### PR TITLE
chore(gitignore): ignore local Devin working files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ android/*
 
 .idea
 .env
+
+# Devin local working files
+AGENTS.md
+AUDIT.md


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` and `AUDIT.md` to `.gitignore`.
- These are Devin local working documents (project rules and internal audit notes) that should not be committed.

## Test plan
- [x] `yarn tsc --noEmit` passes.
- [x] `yarn jest --ci` passes.
- [x] `.gitignore` correctly lists the two files.

Generated with [Devin](https://devin.ai)