### PR TITLE
fix(month): prevent two-digit day numbers from being clipped

### DIFF
--- a/src/features/calendar/components/MonthDayView.tsx
+++ b/src/features/calendar/components/MonthDayView.tsx
@@ -344,7 +344,7 @@ const styles = StyleSheet.create({
   monthPage: { flex: 1 },
   weekRow: { flex: 1, flexDirection: 'row' },
   dayCell: { flex: 1, alignItems: 'center', paddingTop: 2 },
-  dayCircle: { width: 28, height: 28, borderRadius: 14, overflow: 'hidden', alignItems: 'center', justifyContent: 'center' },
+  dayCircle: { width: 32, height: 32, borderRadius: 16, overflow: 'hidden', alignItems: 'center', justifyContent: 'center' },
   dayNumber: { fontSize: 14, textAlign: 'center' },
   dotsRow: { flexDirection: 'row', gap: 2, marginTop: 2 },
   dot: { width: 5, height: 5, borderRadius: 3 },


### PR DESCRIPTION
## Summary
- Increase the day number circle from 28×28 to 32×32 / 16 px radius.
- Two-digit day numbers (e.g. 14) are no longer clipped on devices like Samsung A52 (Android 14).

## Test plan
- [x] `yarn tsc --noEmit` passes.
- [x] `yarn jest --ci` passes.
- [x] Android emulator: two-digit day numbers fully visible in month view.
- [x] Android emulator: single-digit day numbers remain centered.

Closes #89

Generated with [Devin](https://devin.ai)