### PR TITLE
fix(widget): refresh Android widget from local DB on system-triggered updates

### DIFF
--- a/__tests__/features/widget/homeWidget.android.test.tsx
+++ b/__tests__/features/widget/homeWidget.android.test.tsx
@@ -1,0 +1,111 @@
+import type { AgendaSnapshot, AgendaTimelineEntry } from '@/features/widget/core/types';
+
+jest.mock('react-native-android-widget', () => ({
+  registerWidgetTaskHandler: jest.fn(),
+  requestWidgetUpdate: jest.fn(),
+  FlexWidget: 'FlexWidget',
+  ListWidget: 'ListWidget',
+  TextWidget: 'TextWidget',
+}));
+
+jest.mock('@/features/widget/storage/widgetStore', () => ({
+  readAgendaSnapshot: jest.fn((): AgendaSnapshot | null => null),
+  writeAgendaTimeline: jest.fn(),
+}));
+
+const mockBuildFreshTimeline = jest.fn();
+
+jest.mock('@/features/widget/core/buildTimeline', () => ({
+  buildFreshTimeline: (...args: unknown[]) => mockBuildFreshTimeline(...args),
+  AGENDA_DAYS: 7,
+}));
+
+function makeSnapshot(dayNumber: string): AgendaSnapshot {
+  return {
+    generatedAtIso: '2026-08-26T09:00:00.000Z',
+    timeZone: 'Europe/Berlin',
+    scheme: 'light',
+    dayLabel: 'WED',
+    dayNumber,
+    relativeLabel: 'Wednesday, 26 August',
+    events: [],
+    sections: [],
+  };
+}
+
+function makeTimeline(dayNumber: string): AgendaTimelineEntry[] {
+  return [{ atIso: '2026-08-26T09:00:00.000Z', snapshot: makeSnapshot(dayNumber) }];
+}
+
+function handlerProps(action: 'WIDGET_ADDED' | 'WIDGET_UPDATE' | 'WIDGET_CLICK') {
+  const renderWidget = jest.fn();
+  return {
+    widgetInfo: { widgetName: 'CalendarSmallWidget', widgetId: 1, height: 110, width: 110, screenInfo: { screenHeightDp: 800, screenWidthDp: 400, density: 2, densityDpi: 320 } },
+    widgetAction: action,
+    renderWidget,
+  };
+}
+
+describe('widgetTaskHandler (android)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockBuildFreshTimeline.mockReset();
+    const store = require('@/features/widget/storage/widgetStore');
+    store.readAgendaSnapshot.mockReset();
+    store.writeAgendaTimeline.mockReset();
+  });
+
+  it('refreshes from the local DB on WIDGET_UPDATE and renders the fresh snapshot', async () => {
+    const store = require('@/features/widget/storage/widgetStore');
+    store.readAgendaSnapshot.mockReturnValue(makeSnapshot('25'));
+    mockBuildFreshTimeline.mockResolvedValue(makeTimeline('26'));
+
+    const { widgetTaskHandler } = require('@/features/widget/surfaces/homeWidget/homeWidget.android');
+    const props = handlerProps('WIDGET_UPDATE');
+    await widgetTaskHandler(props);
+
+    expect(mockBuildFreshTimeline).toHaveBeenCalledTimes(1);
+    expect(store.writeAgendaTimeline).toHaveBeenCalledWith(makeTimeline('26'));
+    // First render uses the cached snapshot, second uses the fresh one.
+    expect(props.renderWidget).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not refresh from the DB on WIDGET_CLICK', async () => {
+    const store = require('@/features/widget/storage/widgetStore');
+    store.readAgendaSnapshot.mockReturnValue(makeSnapshot('25'));
+
+    const { widgetTaskHandler } = require('@/features/widget/surfaces/homeWidget/homeWidget.android');
+    const props = handlerProps('WIDGET_CLICK');
+    await widgetTaskHandler(props);
+
+    expect(mockBuildFreshTimeline).not.toHaveBeenCalled();
+    expect(store.writeAgendaTimeline).not.toHaveBeenCalled();
+    expect(props.renderWidget).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the cached snapshot when buildFreshTimeline returns null', async () => {
+    const store = require('@/features/widget/storage/widgetStore');
+    store.readAgendaSnapshot.mockReturnValue(makeSnapshot('25'));
+    mockBuildFreshTimeline.mockResolvedValue(null);
+
+    const { widgetTaskHandler } = require('@/features/widget/surfaces/homeWidget/homeWidget.android');
+    const props = handlerProps('WIDGET_UPDATE');
+    await widgetTaskHandler(props);
+
+    expect(mockBuildFreshTimeline).toHaveBeenCalledTimes(1);
+    expect(store.writeAgendaTimeline).not.toHaveBeenCalled();
+    expect(props.renderWidget).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to the cached snapshot when buildFreshTimeline throws', async () => {
+    const store = require('@/features/widget/storage/widgetStore');
+    store.readAgendaSnapshot.mockReturnValue(makeSnapshot('25'));
+    mockBuildFreshTimeline.mockRejectedValue(new Error('DB locked'));
+
+    const { widgetTaskHandler } = require('@/features/widget/surfaces/homeWidget/homeWidget.android');
+    const props = handlerProps('WIDGET_UPDATE');
+    await widgetTaskHandler(props);
+
+    expect(props.renderWidget).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/widget/core/buildTimeline.ts
+++ b/src/features/widget/core/buildTimeline.ts
@@ -10,16 +10,6 @@ import type { AgendaTimelineEntry } from './types';
 
 export const AGENDA_DAYS = 7;
 
-/**
- * Reads upcoming events from the local WatermelonDB and builds a fresh agenda
- * timeline. This does NOT call `requestWidgetUpdate` or touch the live
- * activity — it only produces data. Used by `syncWidget` and the Android
- * `widgetTaskHandler` so that system-triggered widget updates render fresh
- * content even when the app is not open.
- *
- * Returns `null` when there is no active account or the calendar app is
- * unconfigured, so the caller can fall back to the last cached snapshot.
- */
 export async function buildFreshTimeline(now: Date = new Date()): Promise<AgendaTimelineEntry[] | null> {
   if (!useAccountStore.getState().activeAccountId) return null;
   if (useAccountStore.getState().capabilities.calendarApp === 'unconfigured') return null;

--- a/src/features/widget/core/buildTimeline.ts
+++ b/src/features/widget/core/buildTimeline.ts
@@ -1,0 +1,35 @@
+import { Appearance } from 'react-native';
+
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useAccountStore } from '@/stores/accountStore';
+import { useCalendarStore } from '@/stores/calendarStore';
+
+import { readUpcomingEvents } from './readEvents';
+import { buildAgendaTimeline, type BuildAgendaOptions } from './agendaSnapshot';
+import type { AgendaTimelineEntry } from './types';
+
+export const AGENDA_DAYS = 7;
+
+/**
+ * Reads upcoming events from the local WatermelonDB and builds a fresh agenda
+ * timeline. This does NOT call `requestWidgetUpdate` or touch the live
+ * activity — it only produces data. Used by `syncWidget` and the Android
+ * `widgetTaskHandler` so that system-triggered widget updates render fresh
+ * content even when the app is not open.
+ *
+ * Returns `null` when there is no active account or the calendar app is
+ * unconfigured, so the caller can fall back to the last cached snapshot.
+ */
+export async function buildFreshTimeline(now: Date = new Date()): Promise<AgendaTimelineEntry[] | null> {
+  if (!useAccountStore.getState().activeAccountId) return null;
+  if (useAccountStore.getState().capabilities.calendarApp === 'unconfigured') return null;
+
+  const { widgetDisabledCalendarIds } = useCalendarStore.getState();
+  const events = (await readUpcomingEvents(AGENDA_DAYS, now))
+    .filter((event) => !widgetDisabledCalendarIds.includes(event.calendarId));
+  const locale = useSettingsStore.getState().language;
+  const scheme = Appearance.getColorScheme() === 'dark' ? 'dark' : 'light';
+
+  const options: BuildAgendaOptions = { now, locale, scheme, days: AGENDA_DAYS, maxPerSection: 10 };
+  return buildAgendaTimeline(events, options);
+}

--- a/src/features/widget/hooks/useWidgetSync.ts
+++ b/src/features/widget/hooks/useWidgetSync.ts
@@ -6,9 +6,10 @@ import { useCalendarStore } from '@/stores/calendarStore';
 import { EVENT_OBSERVED_COLUMNS } from '@/database/observedColumns';
 
 import { observeAgendaEventsQuery } from '../core/readEvents';
+import { AGENDA_DAYS } from '../core/buildTimeline';
 import { liveActivity } from '../surfaces/liveActivity';
 import { registerWidgetBackgroundSync, unregisterWidgetBackgroundSync } from '../sync/backgroundSync';
-import { AGENDA_DAYS, syncWidget } from '../sync/syncWidget';
+import { syncWidget } from '../sync/syncWidget';
 
 const REFRESH_MS = 60_000;
 

--- a/src/features/widget/surfaces/homeWidget/homeWidget.android.tsx
+++ b/src/features/widget/surfaces/homeWidget/homeWidget.android.tsx
@@ -12,6 +12,7 @@ import type { AgendaEventItem, AgendaSnapshot, AgendaTimelineEntry, WidgetSurfac
 import { type AgendaGroup, agendaGroups, agendaHeader, agendaPalette, compactEvents, emptyLabel } from '../../core/agendaView';
 import { onEventColor, widgetPalette, widgetRadius, widgetSpacing, widgetType } from '../../core/theme';
 import { readAgendaSnapshot, writeAgendaTimeline } from '../../storage/widgetStore';
+import { buildFreshTimeline } from '../../core/buildTimeline';
 
 type Palette = ReturnType<typeof widgetPalette>;
 
@@ -133,8 +134,27 @@ function AndroidWidget({ widgetName, snapshot }: { widgetName: string; snapshot:
 }
 
 export const widgetTaskHandler = async (props: WidgetTaskHandlerProps) => {
-  const snapshot = readAgendaSnapshot();
-  props.renderWidget(<AndroidWidget widgetName={props.widgetInfo.widgetName} snapshot={snapshot} />);
+  // Render immediately with the last cached snapshot so the widget is never blank.
+  const cachedSnapshot = readAgendaSnapshot();
+  props.renderWidget(<AndroidWidget widgetName={props.widgetInfo.widgetName} snapshot={cachedSnapshot} />);
+
+  // When Android triggers a periodic update (every `updatePeriodMillis`) or the
+  // widget is first placed on the home screen, refresh from the local
+  // WatermelonDB so the widget shows current events even when the app is not
+  // open.  We use `props.renderWidget` (not `requestWidgetUpdate`) to avoid an
+  // infinite update loop.
+  if (props.widgetAction === 'WIDGET_ADDED' || props.widgetAction === 'WIDGET_UPDATE') {
+    try {
+      const timeline = await buildFreshTimeline();
+      if (timeline && timeline.length > 0) {
+        writeAgendaTimeline(timeline);
+        const snapshot = timeline[0].snapshot;
+        props.renderWidget(<AndroidWidget widgetName={props.widgetInfo.widgetName} snapshot={snapshot} />);
+      }
+    } catch (error) {
+      if (__DEV__) console.warn('[widget] handler refresh failed', error);
+    }
+  }
 };
 
 export const homeWidget: WidgetSurface<AgendaTimelineEntry[]> = {

--- a/src/features/widget/surfaces/homeWidget/homeWidget.android.tsx
+++ b/src/features/widget/surfaces/homeWidget/homeWidget.android.tsx
@@ -134,15 +134,9 @@ function AndroidWidget({ widgetName, snapshot }: { widgetName: string; snapshot:
 }
 
 export const widgetTaskHandler = async (props: WidgetTaskHandlerProps) => {
-  // Render immediately with the last cached snapshot so the widget is never blank.
   const cachedSnapshot = readAgendaSnapshot();
   props.renderWidget(<AndroidWidget widgetName={props.widgetInfo.widgetName} snapshot={cachedSnapshot} />);
 
-  // When Android triggers a periodic update (every `updatePeriodMillis`) or the
-  // widget is first placed on the home screen, refresh from the local
-  // WatermelonDB so the widget shows current events even when the app is not
-  // open.  We use `props.renderWidget` (not `requestWidgetUpdate`) to avoid an
-  // infinite update loop.
   if (props.widgetAction === 'WIDGET_ADDED' || props.widgetAction === 'WIDGET_UPDATE') {
     try {
       const timeline = await buildFreshTimeline();

--- a/src/features/widget/sync/syncWidget.ts
+++ b/src/features/widget/sync/syncWidget.ts
@@ -5,14 +5,13 @@ import { useSettingsStore } from '@/stores/settingsStore';
 import { useAccountStore } from '@/stores/accountStore';
 import { useCalendarStore } from '@/stores/calendarStore';
 
-import { readUpcomingEvents } from '../core/readEvents';
 import { buildAgendaTimeline } from '../core/agendaSnapshot';
+import { AGENDA_DAYS, buildFreshTimeline } from '../core/buildTimeline';
+import { readUpcomingEvents } from '../core/readEvents';
 import { selectOngoingEvent, shouldClearLiveEvent } from '../core/liveEvent';
 import { readLiveEvent } from '../storage/widgetStore';
 import { homeWidget } from '../surfaces/homeWidget';
 import { liveActivity } from '../surfaces/liveActivity';
-
-export const AGENDA_DAYS = 7;
 
 let running = false;
 let pending = false;


### PR DESCRIPTION
## Summary
Closes #218.

The Android home screen widget was only updating when the user opened the app, because the `widgetTaskHandler` (called by Android every `updatePeriodMillis` — about 30 minutes) only re-rendered the stale MMKV snapshot without fetching fresh data.

This PR changes the Android `widgetTaskHandler` so that on `WIDGET_UPDATE` and `WIDGET_ADDED` it reads upcoming events from the local WatermelonDB, builds a fresh agenda timeline, and re-renders the widget. If the read fails or there is no active account, the handler falls back to the previously cached snapshot.

To avoid an infinite update loop, the handler uses `props.renderWidget` instead of `requestWidgetUpdate`.

To keep imports clean, `buildFreshTimeline` and `AGENDA_DAYS` were extracted from `syncWidget.ts` into a new `src/features/widget/core/buildTimeline.ts`, and are reused both by `syncWidget` and by the widget handler.

## Changes
- `src/features/widget/core/buildTimeline.ts` (new): extracts `buildFreshTimeline` and `AGENDA_DAYS`.
- `src/features/widget/surfaces/homeWidget/homeWidget.android.tsx`: refreshes from the local DB on `WIDGET_UPDATE`/`WIDGET_ADDED`.
- `src/features/widget/sync/syncWidget.ts`: uses `buildFreshTimeline` from the new module.
- `src/features/widget/hooks/useWidgetSync.ts`: imports `AGENDA_DAYS` from the new module.
- `__tests__/features/widget/homeWidget.android.test.tsx` (new): unit tests for `widgetTaskHandler`.

## Test plan
- [x] `yarn tsc --noEmit` passes
- [x] `yarn jest --ci` passes — 603/603 tests
- [x] Android emulator (Pixel 7, API 36): app builds, syncs with Nextcloud Docker, widget renders events

Generated with [Devin](https://devin.ai)