### PR TITLE
feat(event): import .ics files via system open-with

### DIFF
--- a/__tests__/api/caldav.test.ts
+++ b/__tests__/api/caldav.test.ts
@@ -1,4 +1,4 @@
-import { deleteEvent, moveEvent, syncCollection, fetchEvents, fetchEventsByHrefs, fetchCalendars, validateCredentials, MULTIGET_BATCH } from '../../src/services/nextcloud/caldav';
+import { deleteEvent, moveEvent, syncCollection, fetchEvents, fetchEventsByHrefs, fetchCalendars, validateCredentials, MULTIGET_BATCH, buildEventHref } from '../../src/services/nextcloud/caldav';
 import type { Account, CalendarMeta } from '../../src/types';
 
 const account: Account = {
@@ -496,5 +496,21 @@ describe('Nextcloud installed in a subdirectory', () => {
     );
 
     expect(events[0].href).toBe('https://cloud.example.com/nextcloud/remote.php/dav/calendars/john/personal/a.ics');
+  });
+});
+
+describe('buildEventHref', () => {
+  it('encodes UIDs with reserved URL characters', () => {
+    const href = buildEventHref(targetCalendar, 'uid-with@host:part');
+    expect(href).toBe(
+      'https://cloud.example.com/remote.php/dav/calendars/john/work/uid-with%40host%3Apart.ics',
+    );
+  });
+
+  it('leaves plain UUID UIDs unchanged', () => {
+    const href = buildEventHref(targetCalendar, 'plain-uid-123');
+    expect(href).toBe(
+      'https://cloud.example.com/remote.php/dav/calendars/john/work/plain-uid-123.ics',
+    );
   });
 });

--- a/__tests__/app/+native-intent.test.ts
+++ b/__tests__/app/+native-intent.test.ts
@@ -1,0 +1,43 @@
+import { redirectSystemPath } from '../../app/+native-intent';
+
+describe('redirectSystemPath', () => {
+  it('rewrites a content:// .ics URI to the import route', () => {
+    const result = redirectSystemPath({
+      path: 'content://com.android.fileprovider/files/invite.ics',
+      initial: true,
+    });
+    expect(result).toBe(
+      '/event/import?uri=content%3A%2F%2Fcom.android.fileprovider%2Ffiles%2Finvite.ics',
+    );
+  });
+
+  it('rewrites a file:// .ics URI to the import route', () => {
+    const result = redirectSystemPath({
+      path: 'file:///private/var/mobile/Inbox/meeting.ics',
+      initial: true,
+    });
+    expect(result).toBe(
+      '/event/import?uri=file%3A%2F%2F%2Fprivate%2Fvar%2Fmobile%2FInbox%2Fmeeting.ics',
+    );
+  });
+
+  it('passes through app deep links unchanged', () => {
+    const result = redirectSystemPath({
+      path: 'nextcloud-calendar://settings',
+      initial: true,
+    });
+    expect(result).toBe('nextcloud-calendar://settings');
+  });
+
+  it('passes through unrelated file types unchanged', () => {
+    const result = redirectSystemPath({
+      path: 'file:///storage/document.pdf',
+      initial: true,
+    });
+    expect(result).toBe('file:///storage/document.pdf');
+  });
+
+  it('falls back to root on empty input', () => {
+    expect(redirectSystemPath({ path: '', initial: true })).toBe('/');
+  });
+});

--- a/__tests__/features/event/icsImport.test.ts
+++ b/__tests__/features/event/icsImport.test.ts
@@ -1,0 +1,131 @@
+jest.mock('expo-file-system/legacy', () => ({
+  cacheDirectory: 'file:///cache/',
+  copyAsync: jest.fn(),
+  readAsStringAsync: jest.fn(),
+  deleteAsync: jest.fn(),
+}));
+
+import * as FileSystem from 'expo-file-system/legacy';
+
+import {
+  IcsImportError,
+  sanitizeIcs,
+  parseIcsToEvents,
+  extractOrganizerName,
+  eventToFormValues,
+  readIcsUri,
+} from '@/features/event/utils/icsImport';
+
+const sampleIcs = `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nPRODID:-//Test//EN\r\nBEGIN:VEVENT\r\nUID:event-abc-123\r\nSUMMARY:Team Meeting\r\nDTSTART:20260601T140000Z\r\nDTEND:20260601T150000Z\r\nDESCRIPTION:Weekly sync\r\nLOCATION:Room A\r\nORGANIZER;CN=John Doe:mailto:john@example.com\r\nATTENDEE;CN=Alice;RSVP=TRUE:mailto:alice@example.com\r\nCATEGORIES:meeting\r\nEXDATE:20260608T140000Z\r\nEND:VEVENT\r\nEND:VCALENDAR`;
+
+const multiEventIcs = `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VEVENT\r\nUID:first-uid\r\nSUMMARY:First Event\r\nDTSTART:20260601T100000Z\r\nDTEND:20260601T110000Z\r\nEND:VEVENT\r\nBEGIN:VEVENT\r\nUID:second-uid\r\nSUMMARY:Second Event\r\nDTSTART:20260602T100000Z\r\nDTEND:20260602T110000Z\r\nEND:VEVENT\r\nEND:VCALENDAR`;
+
+const todoIcs = `BEGIN:VCALENDAR\r\nVERSION:2.0\r\nBEGIN:VTODO\r\nUID:todo-1\r\nSUMMARY:A task\r\nDUE:20260601T120000Z\r\nEND:VTODO\r\nEND:VCALENDAR`;
+
+const { copyAsync, readAsStringAsync, deleteAsync } = FileSystem as unknown as {
+  copyAsync: jest.Mock;
+  readAsStringAsync: jest.Mock;
+  deleteAsync: jest.Mock;
+};
+
+describe('sanitizeIcs', () => {
+  it('removes a UTF-8 BOM', () => {
+    const withBom = `\uFEFF${sampleIcs}`;
+    expect(sanitizeIcs(withBom)).not.toMatch(/^\uFEFF/);
+  });
+
+  it('normalizes mixed line endings to CRLF', () => {
+    const lfOnly = sampleIcs.replace(/\r\n/g, '\n');
+    const sanitized = sanitizeIcs(lfOnly);
+    expect(sanitized).toContain('BEGIN:VEVENT\r\n');
+    expect(sanitized).not.toMatch(/[^\r]\n/);
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    const padded = `\n\n${sampleIcs}\n\n`;
+    expect(sanitizeIcs(padded)).toMatch(/^BEGIN:VCALENDAR/);
+    expect(sanitizeIcs(padded)).toMatch(/END:VCALENDAR$/);
+  });
+});
+
+describe('parseIcsToEvents', () => {
+  it('parses a single VEVENT into a CalendarEvent', () => {
+    const [event] = parseIcsToEvents(sampleIcs);
+    expect(event.uid).toBe('event-abc-123');
+    expect(event.summary).toBe('Team Meeting');
+    expect(event.allDay).toBe(false);
+    expect(event.attendees).toHaveLength(1);
+    expect(event.attendees[0].email).toBe('alice@example.com');
+  });
+
+  it('returns multiple master VEVENTs from one file', () => {
+    const events = parseIcsToEvents(multiEventIcs);
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.uid)).toEqual(['first-uid', 'second-uid']);
+  });
+
+  it('ignores VTODOs', () => {
+    const events = parseIcsToEvents(todoIcs);
+    expect(events).toHaveLength(0);
+  });
+});
+
+describe('extractOrganizerName', () => {
+  it('returns the ORGANIZER CN parameter for the matching UID', () => {
+    expect(extractOrganizerName(sampleIcs, 'event-abc-123')).toBe('John Doe');
+  });
+
+  it('returns undefined when the event has no organizer', () => {
+    expect(extractOrganizerName(multiEventIcs, 'first-uid')).toBeUndefined();
+  });
+});
+
+describe('eventToFormValues', () => {
+  it('carries the UID and parsed extra lines', () => {
+    const [event] = parseIcsToEvents(sampleIcs);
+    const form = eventToFormValues(event, sampleIcs);
+    expect(form.uid).toBe('event-abc-123');
+    expect(form.extraLines).toContain('CATEGORIES:meeting');
+    expect(form.extraLines).toContain('EXDATE:20260608T140000Z');
+    expect(form.summary).toBe('Team Meeting');
+    expect(form.rrule).toBeUndefined();
+  });
+});
+
+describe('readIcsUri', () => {
+  beforeEach(() => {
+    copyAsync.mockReset();
+    readAsStringAsync.mockReset();
+    deleteAsync.mockReset();
+  });
+
+  it('copies a content:// URI to cache, reads, and cleans up', async () => {
+    copyAsync.mockResolvedValue(undefined);
+    readAsStringAsync.mockResolvedValue(sampleIcs);
+    deleteAsync.mockResolvedValue(undefined);
+
+    const result = await readIcsUri('content://com.example/files/test.ics');
+    expect(result).toBe(sampleIcs);
+    expect(copyAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ from: 'content://com.example/files/test.ics' }),
+    );
+    expect(deleteAsync).toHaveBeenCalled();
+  });
+
+  it('throws an IcsImportError when reading fails', async () => {
+    copyAsync.mockResolvedValue(undefined);
+    readAsStringAsync.mockRejectedValue(new Error('permission denied'));
+
+    await expect(readIcsUri('content://com.example/files/test.ics')).rejects.toBeInstanceOf(
+      IcsImportError,
+    );
+  });
+
+  it('reads a file:// URI directly', async () => {
+    readAsStringAsync.mockResolvedValue(sampleIcs);
+
+    const result = await readIcsUri('file:///data/data/test.ics');
+    expect(result).toBe(sampleIcs);
+    expect(copyAsync).not.toHaveBeenCalled();
+  });
+});

--- a/app.config.ts
+++ b/app.config.ts
@@ -40,6 +40,28 @@ const config: ExpoConfig = {
             NSAppTransportSecurity: {
                 NSAllowsArbitraryLoads: true,
             },
+            CFBundleDocumentTypes: [
+                {
+                    CFBundleTypeName: 'iCalendar File',
+                    CFBundleTypeRole: 'Editor',
+                    LSHandlerRank: 'Alternate',
+                    LSItemContentTypes: [
+                        'com.apple.ical.ics',
+                        'public.data',
+                    ],
+                },
+            ],
+            UTImportedTypeDeclarations: [
+                {
+                    UTTypeConformsTo: ['public.data', 'public.content'],
+                    UTTypeDescription: 'iCalendar File',
+                    UTTypeIdentifier: 'com.soluce.nextcloud-calendar.ics',
+                    UTTypeTagSpecification: {
+                        'public.filename-extension': ['ics'],
+                        'public.mime-type': ['text/calendar', 'application/ics'],
+                    },
+                },
+            ],
         },
         entitlements: {
             'com.apple.security.application-groups': ['group.com.soluce.nextcloud-calendar'],
@@ -54,6 +76,26 @@ const config: ExpoConfig = {
             backgroundColor: '#109be6',
         },
         softwareKeyboardLayoutMode: 'resize',
+        intentFilters: [
+            {
+                action: 'VIEW',
+                category: ['DEFAULT', 'BROWSABLE'],
+                data: [
+                    { scheme: 'content', mimeType: 'text/calendar' },
+                    { scheme: 'content', mimeType: 'application/ics' },
+                    { scheme: 'file', mimeType: 'text/calendar' },
+                    { scheme: 'file', mimeType: 'application/ics' },
+                ],
+            },
+            {
+                action: 'VIEW',
+                category: ['DEFAULT', 'BROWSABLE'],
+                data: [
+                    { scheme: 'content', mimeType: '*/*', pathPattern: '/.*\\.ics' },
+                    { scheme: 'file', mimeType: '*/*', pathPattern: '/.*\\.ics' },
+                ],
+            },
+        ],
     },
 
     web: {

--- a/app/+native-intent.ts
+++ b/app/+native-intent.ts
@@ -1,0 +1,13 @@
+export function redirectSystemPath({ path, initial }: { path: string; initial: boolean }): string {
+  if (!path) return '/';
+
+  try {
+    if (path.startsWith('content://') || (path.startsWith('file://') && /\.ics$/i.test(path))) {
+      return `/event/import?uri=${encodeURIComponent(path)}`;
+    }
+  } catch {
+    return '/';
+  }
+
+  return path;
+}

--- a/app/event/import.tsx
+++ b/app/event/import.tsx
@@ -1,0 +1,10 @@
+import { useLocalSearchParams } from 'expo-router';
+import { IcsImportScreen } from '@/features/event/components/IcsImportScreen';
+
+export default function IcsImportRoute() {
+  const { uri } = useLocalSearchParams<{ uri?: string }>();
+
+  if (!uri) return null;
+
+  return <IcsImportScreen uri={uri} />;
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "expo-constants": "~57.0.6",
     "expo-crypto": "~57.0.1",
     "expo-dev-client": "~57.0.9",
+    "expo-file-system": "~57.0.2",
     "expo-font": "~57.0.1",
     "expo-haptics": "~57.0.1",
     "expo-linking": "~57.0.3",

--- a/src/features/event/components/EventForm.tsx
+++ b/src/features/event/components/EventForm.tsx
@@ -15,7 +15,7 @@ import type { CalendarMeta, Attendee, CreateEventInput, RecurrenceRule, TalkRoom
 
 dayjs.extend(localizedFormat);
 
-interface InitialValues {
+export interface InitialValues {
   summary?: string;
   calendarId?: string;
   allDay?: boolean;
@@ -26,6 +26,8 @@ interface InitialValues {
   attendees?: Attendee[];
   rrule?: RecurrenceRule;
   alarmMinutes?: number;
+  uid?: string;
+  extraLines?: string[];
 }
 
 interface Props {
@@ -199,6 +201,8 @@ export function EventForm({
       summary: summary.trim(), calendarId, dtstart, dtend, allDay,
       description, location, attendees, withTalkRoom, talkRoomType,
       organizerEmail, organizerName, rrule, alarmMinutes,
+      uid: initialValues?.uid,
+      extraLines: initialValues?.extraLines,
     });
   }
 

--- a/src/features/event/components/IcsImportScreen.tsx
+++ b/src/features/event/components/IcsImportScreen.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ScrollView, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
+import localizedFormat from 'dayjs/plugin/localizedFormat';
+
+import { useAccounts } from '@/hooks/useAccounts';
+import { useCalendars } from '@/hooks/useCalendars';
+import { useAccountStore } from '@/stores/accountStore';
+import { useCreateEvent } from '@/features/event/hooks/useMutateEvent';
+import { useImportIcs } from '@/features/event/hooks/useImportIcs';
+import { resolveOrganizer } from '@/features/event/utils/organizer';
+import {
+  eventToFormValues,
+  extractOrganizerName,
+} from '@/features/event/utils/icsImport';
+import { goBackOrHome } from '@/utils/navigationGuard';
+import { EventForm } from '@/features/event/components/EventForm';
+import {
+  ViewContainer,
+  Stack,
+  Typography,
+  Button,
+  Spinner,
+  ScreenHeader,
+  List,
+  Item,
+} from '@/ui/components';
+import type { CalendarEvent, CreateEventInput } from '@/types';
+
+dayjs.extend(localizedFormat);
+
+interface Props {
+  uri: string;
+}
+
+function formatEventDate(event: CalendarEvent): string {
+  const start = dayjs(event.dtstart).format('lll');
+  const end = dayjs(event.dtend).format('lll');
+  return event.allDay ? dayjs(event.dtstart).format('LL') : `${start} – ${end}`;
+}
+
+export function IcsImportScreen({ uri }: Props) {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { loading, error, events, originalIcs, reload } = useImportIcs(uri);
+
+  const activeAccountId = useAccountStore((s) => s.activeAccountId);
+  const accounts = useAccounts();
+  const activeAccount = accounts.find((a) => a.id === activeAccountId) ?? null;
+  const { data: calendars = [] } = useCalendars(activeAccount);
+
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
+  const [savedUids, setSavedUids] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    setSavedUids(new Set());
+    setSelectedEvent(null);
+  }, [uri]);
+
+  const visibleEvents = useMemo(
+    () => events.filter((e) => !savedUids.has(e.uid)),
+    [events, savedUids],
+  );
+
+  const createMutation = useCreateEvent(activeAccount!, calendars);
+
+  const handleSubmit = useCallback(
+    async (input: CreateEventInput) => {
+      try {
+        await createMutation.mutateAsync(input);
+        const nextSaved = new Set(savedUids);
+        nextSaved.add(input.uid!);
+        setSavedUids(nextSaved);
+        const remaining = events.filter((e) => !nextSaved.has(e.uid));
+        if (remaining.length === 0) {
+          goBackOrHome(router);
+        } else {
+          setSelectedEvent(null);
+        }
+      } catch {
+        // useCreateEvent already shows an alert
+      }
+    },
+    [createMutation, events, router, savedUids],
+  );
+
+  if (!activeAccount) {
+    return (
+      <ViewContainer>
+        <SafeAreaView style={styles.flex}>
+          <ScreenHeader title={t('import.title')} onBack={() => router.back()} />
+          <Stack flex vAlign="center" hAlign="center" gap={16}>
+            <Typography variant="body1" color="secondary">{t('import.errorNoAccount')}</Typography>
+            <Button variant="primary" title={t('import.back')} onPress={() => router.back()} />
+          </Stack>
+        </SafeAreaView>
+      </ViewContainer>
+    );
+  }
+
+  if (loading) {
+    return (
+      <ViewContainer>
+        <SafeAreaView style={styles.flex}>
+          <ScreenHeader title={t('import.title')} onBack={() => router.back()} />
+          <Stack flex vAlign="center" hAlign="center">
+            <Spinner size="large" />
+          </Stack>
+        </SafeAreaView>
+      </ViewContainer>
+    );
+  }
+
+  if (error) {
+    return (
+      <ViewContainer>
+        <SafeAreaView style={styles.flex}>
+          <ScreenHeader title={t('import.title')} onBack={() => router.back()} />
+          <Stack padding={20} gap={16} vAlign="center" hAlign="center">
+            <Typography variant="body1" color="danger">{error}</Typography>
+            <Button variant="primary" title={t('import.retry')} onPress={reload} />
+          </Stack>
+        </SafeAreaView>
+      </ViewContainer>
+    );
+  }
+
+  if (visibleEvents.length === 0) {
+    return (
+      <ViewContainer>
+        <SafeAreaView style={styles.flex}>
+          <ScreenHeader title={t('import.title')} onBack={() => router.back()} />
+          <Stack flex vAlign="center" hAlign="center" gap={16}>
+            <Typography variant="body1" color="secondary">{t('import.noEventsFound')}</Typography>
+            <Button variant="primary" title={t('import.back')} onPress={() => router.back()} />
+          </Stack>
+        </SafeAreaView>
+      </ViewContainer>
+    );
+  }
+
+  if (selectedEvent) {
+    const { organizerEmail, organizerName } = resolveOrganizer(activeAccount);
+    const importedEmail = selectedEvent.organizerEmail ?? organizerEmail;
+    const importedName =
+      extractOrganizerName(originalIcs, selectedEvent.uid) ?? organizerName;
+
+    return (
+      <ViewContainer>
+        <SafeAreaView style={styles.flex}>
+          <ScreenHeader
+            title={t('import.importEvent')}
+            onBack={() => setSelectedEvent(null)}
+          />
+          <EventForm
+            calendars={calendars}
+            organizerEmail={importedEmail}
+            organizerName={importedName}
+            onSubmit={handleSubmit}
+            loading={createMutation.isPending}
+            initialValues={eventToFormValues(selectedEvent, originalIcs)}
+            submitLabel={t('import.importEvent')}
+          />
+        </SafeAreaView>
+      </ViewContainer>
+    );
+  }
+
+  return (
+    <ViewContainer>
+      <SafeAreaView style={styles.flex}>
+        <ScreenHeader title={t('import.title')} onBack={() => router.back()} />
+        <ScrollView contentContainerStyle={styles.scrollContent}>
+          <Stack padding={20} gap={16}>
+            <Typography variant="body1" color="secondary">
+              {t('import.selectEvent')}
+            </Typography>
+            <List>
+              {visibleEvents.map((event) => (
+                <Item
+                  key={event.uid}
+                  title={event.summary || t('import.untitledEvent')}
+                  description={formatEventDate(event)}
+                  onPress={() => setSelectedEvent(event)}
+                />
+              ))}
+            </List>
+          </Stack>
+        </ScrollView>
+      </SafeAreaView>
+    </ViewContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  scrollContent: { paddingBottom: 40 },
+});

--- a/src/features/event/hooks/useImportIcs.ts
+++ b/src/features/event/hooks/useImportIcs.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  IcsImportError,
+  parseIcsToEvents,
+  readIcsUri,
+  sanitizeIcs,
+} from '@/features/event/utils/icsImport';
+import type { CalendarEvent } from '@/types';
+
+export interface UseImportIcsResult {
+  loading: boolean;
+  error: string | null;
+  events: CalendarEvent[];
+  originalIcs: string;
+  reload: () => void;
+}
+
+export function useImportIcs(uri: string | undefined): UseImportIcsResult {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const [originalIcs, setOriginalIcs] = useState('');
+
+  const load = useCallback(async () => {
+    if (!uri) {
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const raw = await readIcsUri(uri);
+      const sanitized = sanitizeIcs(raw);
+      setOriginalIcs(sanitized);
+      const parsed = parseIcsToEvents(sanitized);
+      setEvents(parsed);
+    } catch (err) {
+      setError(err instanceof IcsImportError ? err.message : 'Unknown import error');
+    } finally {
+      setLoading(false);
+    }
+  }, [uri]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { loading, error, events, originalIcs, reload: load };
+}

--- a/src/features/event/hooks/useMutateEvent.ts
+++ b/src/features/event/hooks/useMutateEvent.ts
@@ -3,7 +3,7 @@ import { Alert } from 'react-native';
 import * as Crypto from 'expo-crypto';
 import dayjs from 'dayjs';
 
-import { putEvent, updateEvent, deleteEvent, moveEvent, fetchEventIcs } from '@/services/nextcloud/caldav';
+import { putEvent, updateEvent, deleteEvent, moveEvent, fetchEventIcs, buildEventHref } from '@/services/nextcloud/caldav';
 import { createTalkRoom } from '@/services/nextcloud/talk';
 import { describeMutationError } from '@/services/shared/errors';
 import { buildIcs, buildAllDayIcs, buildExceptionIcs, injectExdate, truncateRruleUntil, shiftIcsDates } from '@/utils/ics';
@@ -147,7 +147,7 @@ function eventFromInput(
   const { dtstart, dtend } = inputDates(input);
   return {
     uid,
-    href: `${calendar.url}${uid}.ics`,
+    href: buildEventHref(calendar, uid),
     calendarId: calendar.id,
     accountId: account.id,
     summary: input.summary,
@@ -171,13 +171,16 @@ function expandOccurrences(
   input: CreateEventInput,
   calendar: CalendarMeta,
   account: Account,
+  resolved?: { location: string; description: string },
 ): CalendarEvent[] {
   const timezone = resolveTimezone(account);
-  const ics = buildIcsForInput(baseUid, input, input.location ?? '', input.description ?? '', timezone);
+  const location = resolved?.location ?? input.location ?? '';
+  const description = resolved?.description ?? input.description ?? '';
+  const ics = buildIcsForInput(baseUid, input, location, description, timezone, 0, input.extraLines);
   const rangeStart = dayjs(input.dtstart).subtract(1, 'month').toDate();
   const rangeEnd = dayjs(input.dtstart).add(3, 'month').toDate();
   return parseIcsObjects(
-    [{ ics, href: `${calendar.url}${baseUid}.ics` }],
+    [{ ics, href: buildEventHref(calendar, baseUid) }],
     { calendarId: calendar.id, accountId: account.id, color: calendar.color },
     rangeStart,
     rangeEnd,
@@ -190,7 +193,7 @@ export function useCreateEvent(account: Account, calendars: CalendarMeta[]) {
       const calendar = resolveCalendar(calendars, input.calendarId);
       if (!calendar) return;
 
-      const uid = Crypto.randomUUID();
+      const uid = input.uid ?? Crypto.randomUUID();
       const optimistic = input.rrule
         ? expandOccurrences(uid, input, calendar, account)
         : [eventFromInput(uid, input, calendar, account)];
@@ -199,11 +202,11 @@ export function useCreateEvent(account: Account, calendars: CalendarMeta[]) {
       try {
         const resolved = await resolveLocationAndDescription(account, input);
         const timezone = resolveTimezone(account);
-        const ics = buildIcsForInput(uid, input, resolved.location, resolved.description, timezone);
+        const ics = buildIcsForInput(uid, input, resolved.location, resolved.description, timezone, 0, input.extraLines);
         await putEvent(account, calendar, uid, ics);
 
         const real = input.rrule
-          ? expandOccurrences(uid, input, calendar, account)
+          ? expandOccurrences(uid, input, calendar, account, resolved)
           : [eventFromInput(uid, input, calendar, account, resolved)];
         await insertEvents(real);
       } catch (error) {
@@ -245,7 +248,7 @@ export function useUpdateEvent(account: Account, calendars: CalendarMeta[]) {
           ...(targetCal && {
             calendarId: targetCal.id,
             color: targetCal.color,
-            href: `${targetCal.url}${event.uid}.ics`,
+            href: buildEventHref(targetCal, event.uid),
           }),
         });
       }

--- a/src/features/event/utils/icsImport.ts
+++ b/src/features/event/utils/icsImport.ts
@@ -1,0 +1,102 @@
+import ICAL from 'ical.js';
+import * as FileSystem from 'expo-file-system/legacy';
+
+import { extractExtraVeventLines, parseIcsItem, parseIcsToJcal } from '@/utils/caldav-parse';
+import { parseRrule } from '@/features/calendar/utils/parseRrule';
+import type { InitialValues } from '@/features/event/components/EventForm';
+import type { CalendarEvent } from '@/types';
+
+const IMPORT_META = { calendarId: 'import', accountId: 'import', color: '#1976d2' };
+
+export class IcsImportError extends Error {}
+
+export async function readIcsUri(uri: string): Promise<string> {
+  const cacheFile = `${FileSystem.cacheDirectory ?? ''}ics_import_${Date.now()}.ics`;
+  if (!FileSystem.cacheDirectory) {
+    throw new IcsImportError('No cache directory available');
+  }
+
+  let sourceUri = uri;
+  if (uri.startsWith('content://')) {
+    try {
+      await FileSystem.copyAsync({ from: uri, to: cacheFile });
+      sourceUri = cacheFile;
+    } catch (error) {
+      throw new IcsImportError(
+        `Cannot read content URI: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  try {
+    return await FileSystem.readAsStringAsync(sourceUri, { encoding: 'utf8' });
+  } catch (error) {
+    throw new IcsImportError(
+      `Cannot read .ics file: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  } finally {
+    if (sourceUri === cacheFile) {
+      try {
+        await FileSystem.deleteAsync(cacheFile);
+      } catch {
+        // ignored
+      }
+    }
+  }
+}
+
+export function sanitizeIcs(ics: string): string {
+  return ics
+    .replace(/^\uFEFF/, '')
+    .replace(/\r\n?|\n/g, '\r\n')
+    .trim();
+}
+
+export function parseIcsToEvents(ics: string): CalendarEvent[] {
+  const parsed = parseIcsItem(
+    { ics, href: 'import.ics' },
+    IMPORT_META,
+    undefined,
+    undefined,
+  );
+  return parsed.filter((event) => !event.isTask);
+}
+
+export function extractOrganizerName(ics: string, uid: string): string | undefined {
+  try {
+    const comp = new ICAL.Component(parseIcsToJcal(ics));
+    const vevent = comp
+      .getAllSubcomponents('vevent')
+      .find((v: ICAL.Component) => {
+        if (v.getFirstPropertyValue('recurrence-id')) return false;
+        return v.getFirstPropertyValue('uid') === uid;
+      });
+    if (!vevent) return undefined;
+    const organizer = vevent.getFirstProperty('organizer');
+    if (!organizer) return undefined;
+    const cn = organizer.getParameter('cn') as string | undefined;
+    return cn?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function eventToFormValues(
+  event: CalendarEvent,
+  originalIcs: string,
+): InitialValues & { uid: string; extraLines: string[] } {
+  return {
+    summary: event.summary,
+    calendarId: event.calendarId,
+    allDay: event.allDay,
+    dtstart: event.dtstart,
+    dtend: event.dtend,
+    description: event.description,
+    location: event.location,
+    attendees: [...event.attendees],
+    rrule: parseRrule(event.rrule),
+    alarmMinutes: event.alarmMinutes,
+    uid: event.uid,
+    extraLines: extractExtraVeventLines(originalIcs, event.uid),
+  };
+}

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -147,6 +147,18 @@
     "errorDeleteFailed": "Ereignis konnte nicht gelöscht werden",
     "alert": "Erinnerung"
   },
+  "import": {
+    "title": "Import Event",
+    "selectEvent": "Select an event to import",
+    "noEventsFound": "No events found in this file.",
+    "fileError": "Could not read the file.",
+    "parseError": "Could not parse the .ics file.",
+    "importEvent": "Import Event",
+    "retry": "Retry",
+    "back": "Back",
+    "errorNoAccount": "Please set up a Nextcloud account first.",
+    "untitledEvent": "(No title)"
+  },
   "settings": {
     "title": "Einstellungen",
     "appearance": "Darstellung",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -147,6 +147,18 @@
     "errorDeleteFailed": "Failed to delete event",
     "alert": "Alert"
   },
+  "import": {
+    "title": "Import Event",
+    "selectEvent": "Select an event to import",
+    "noEventsFound": "No events found in this file.",
+    "fileError": "Could not read the file.",
+    "parseError": "Could not parse the .ics file.",
+    "importEvent": "Import Event",
+    "retry": "Retry",
+    "back": "Back",
+    "errorNoAccount": "Please set up a Nextcloud account first.",
+    "untitledEvent": "(No title)"
+  },
   "settings": {
     "title": "Settings",
     "appearance": "Appearance",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -147,6 +147,18 @@
     "errorDeleteFailed": "No se pudo eliminar el evento",
     "alert": "Alerta"
   },
+  "import": {
+    "title": "Import Event",
+    "selectEvent": "Select an event to import",
+    "noEventsFound": "No events found in this file.",
+    "fileError": "Could not read the file.",
+    "parseError": "Could not parse the .ics file.",
+    "importEvent": "Import Event",
+    "retry": "Retry",
+    "back": "Back",
+    "errorNoAccount": "Please set up a Nextcloud account first.",
+    "untitledEvent": "(No title)"
+  },
   "settings": {
     "title": "Ajustes",
     "appearance": "Apariencia",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -147,6 +147,18 @@
     "errorDeleteFailed": "Échec de la suppression de l'événement",
     "alert": "Alerte"
   },
+  "import": {
+    "title": "Importer un événement",
+    "selectEvent": "Sélectionnez un événement à importer",
+    "noEventsFound": "Aucun événement trouvé dans ce fichier.",
+    "fileError": "Impossible de lire le fichier.",
+    "parseError": "Impossible d'analyser le fichier .ics.",
+    "importEvent": "Importer l'événement",
+    "retry": "Réessayer",
+    "back": "Retour",
+    "errorNoAccount": "Veuillez d'abord configurer un compte Nextcloud.",
+    "untitledEvent": "(Sans titre)"
+  },
   "settings": {
     "title": "Paramètres",
     "appearance": "Apparence",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -147,6 +147,18 @@
     "errorDeleteFailed": "Eliminazione dell'evento non riuscita",
     "alert": "Avviso"
   },
+  "import": {
+    "title": "Import Event",
+    "selectEvent": "Select an event to import",
+    "noEventsFound": "No events found in this file.",
+    "fileError": "Could not read the file.",
+    "parseError": "Could not parse the .ics file.",
+    "importEvent": "Import Event",
+    "retry": "Retry",
+    "back": "Back",
+    "errorNoAccount": "Please set up a Nextcloud account first.",
+    "untitledEvent": "(No title)"
+  },
   "settings": {
     "title": "Impostazioni",
     "appearance": "Aspetto",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -147,6 +147,18 @@
     "errorDeleteFailed": "Не удалось удалить событие",
     "alert": "Напоминание"
   },
+  "import": {
+    "title": "Import Event",
+    "selectEvent": "Select an event to import",
+    "noEventsFound": "No events found in this file.",
+    "fileError": "Could not read the file.",
+    "parseError": "Could not parse the .ics file.",
+    "importEvent": "Import Event",
+    "retry": "Retry",
+    "back": "Back",
+    "errorNoAccount": "Please set up a Nextcloud account first.",
+    "untitledEvent": "(No title)"
+  },
   "settings": {
     "title": "Настройки",
     "appearance": "Оформление",

--- a/src/services/nextcloud/caldav.ts
+++ b/src/services/nextcloud/caldav.ts
@@ -371,13 +371,17 @@ export async function fetchEventIcs(account: Account, href: string): Promise<str
   return res.text();
 }
 
+export function buildEventHref(calendar: CalendarMeta, uid: string): string {
+  return `${calendar.url}${encodeURIComponent(uid)}.ics`;
+}
+
 export async function putEvent(
   account: Account,
   calendar: CalendarMeta,
   uid: string,
   ics: string
 ): Promise<void> {
-  const url = `${calendar.url}${uid}.ics`;
+  const url = buildEventHref(calendar, uid);
   const res = await davFetch(url, account, {
     method: 'PUT',
     headers: { 'Content-Type': 'text/calendar; charset=utf-8' },
@@ -413,7 +417,7 @@ export async function moveEvent(
   targetCalendar: CalendarMeta,
   uid: string
 ): Promise<void> {
-  const destination = `${targetCalendar.url}${uid}.ics`;
+  const destination = buildEventHref(targetCalendar, uid);
   const res = await davFetch(fromHref, account, {
     method: 'MOVE',
     headers: { Destination: destination, Overwrite: 'T' },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,6 +83,8 @@ export type CreateEventInput = {
   organizerName: string;
   rrule?: RecurrenceRule;
   alarmMinutes?: number;
+  uid?: string;
+  extraLines?: string[];
 };
 
 export type CalendarAppStatus = 'unknown' | 'available' | 'unconfigured';

--- a/src/utils/caldav-parse.ts
+++ b/src/utils/caldav-parse.ts
@@ -141,7 +141,7 @@ function repairIcsFolding(ics: string): string {
   return out.join('\r\n');
 }
 
-function parseIcsToJcal(ics: string): ReturnType<typeof ICAL.parse> {
+export function parseIcsToJcal(ics: string): ReturnType<typeof ICAL.parse> {
   try {
     return ICAL.parse(ics);
   } catch {
@@ -378,13 +378,19 @@ const WRITER_MANAGED_PROPS = new Set([
   'location', 'rrule', 'organizer', 'attendee', 'recurrence-id', 'last-modified', 'prodid',
 ]);
 
-export function extractExtraVeventLines(ics: string): string[] {
+export function extractExtraVeventLines(ics: string, targetUid?: string): string[] {
   try {
     const comp = new ICAL.Component(parseIcsToJcal(ics));
     const vevents = comp.getAllSubcomponents('vevent');
     if (vevents.length === 0) return [];
     const master =
-      vevents.find((v: ICAL.Component) => !v.getFirstPropertyValue('recurrence-id')) ?? vevents[0];
+      vevents.find((v: ICAL.Component) => {
+        if (v.getFirstPropertyValue('recurrence-id')) return false;
+        if (!targetUid) return true;
+        const uid = v.getFirstPropertyValue('uid');
+        return uid === targetUid;
+      }) ??
+      vevents[0];
     return master
       .getAllProperties()
       .filter((p: ICAL.Property) => !WRITER_MANAGED_PROPS.has(p.name))

--- a/yarn.lock
+++ b/yarn.lock
@@ -8559,6 +8559,7 @@ __metadata:
     expo-constants: "npm:~57.0.6"
     expo-crypto: "npm:~57.0.1"
     expo-dev-client: "npm:~57.0.9"
+    expo-file-system: "npm:~57.0.2"
     expo-font: "npm:~57.0.1"
     expo-haptics: "npm:~57.0.1"
     expo-linking: "npm:~57.0.3"


### PR DESCRIPTION
## Summary
- Register Android intent filters and iOS document types for `.ics` files in `app.config.ts`.
- Add `app/+native-intent.ts` to intercept `content://` / `file://` `.ics` URIs and redirect them to a new `/event/import` route.
- Add `src/features/event/utils/icsImport.ts` to read, sanitize, parse and map ICS events to `CreateEventInput` while preserving the original `UID` and extra VEVENT lines.
- Add `useImportIcs` hook and `IcsImportScreen` UI to let the user pick one event from a multi-event `.ics` file and pre-fill `EventForm`.
- Extend `EventForm`, `useMutateEvent` and CalDAV URL building to carry `uid` and `extraLines` through creation and update, and URL-encode the UID in the CalDAV href.
- Add i18n keys for the import flow in `en`, `fr`, `de`, `es`, `it` and `ru`.
- Add unit tests for `icsImport`, `+native-intent` and `buildEventHref`.

Closes #95

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn jest --ci` (684 tests, 73 suites passing)
- [x] `npx expo prebuild --platform android` and `npx expo run:android` on `nc-cal-api36`
- [x] App appears in the Android "Open with" chooser for `text/calendar` files
- [x] Import screen reads/parses the `.ics` and pre-fills the event form (title, dates, description)

## Notes
- Native `android/` and `ios/` directories are generated by prebuild and were not committed, per project convention.
- `AndroidManifest.xml` was verified to contain the new intent filters after prebuild.

Generated with [Devin](https://devin.ai)